### PR TITLE
Display selected benchmark names by default

### DIFF
--- a/JetStream.css
+++ b/JetStream.css
@@ -301,6 +301,7 @@ a.button {
     background: linear-gradient(160deg, rgba(249,249,249,1) 0%, rgba(238,238,238,1) 100%);
     border-radius: 3px;
 }
+
 .benchmark h3 {
     color:  rgb(183, 183, 183);
 }

--- a/JetStream.css
+++ b/JetStream.css
@@ -296,10 +296,13 @@ a.button {
 
 }
 
-.benchmark h3, .benchmark h4, .benchmark .result, .benchmark label {
+ .benchmark h4, .benchmark .result, .benchmark label {
     color: transparent;
     background: linear-gradient(160deg, rgba(249,249,249,1) 0%, rgba(238,238,238,1) 100%);
     border-radius: 3px;
+}
+.benchmark h3 {
+    color:  rgb(183, 183, 183);
 }
 
 .benchmark-running h4, .benchmark-running .result, .benchmark-running label {

--- a/JetStream.css
+++ b/JetStream.css
@@ -296,7 +296,7 @@ a.button {
 
 }
 
- .benchmark h4, .benchmark .result, .benchmark label {
+.benchmark h4, .benchmark .result, .benchmark label {
     color: transparent;
     background: linear-gradient(160deg, rgba(249,249,249,1) 0%, rgba(238,238,238,1) 100%);
     border-radius: 3px;


### PR DESCRIPTION
By default all benchmark data is "censored".
Showing the benchmark names at the start is more helpful, especially when filtering is enabled.

<img width="896" alt="Screenshot 2024-11-22 at 10 27 13" src="https://github.com/user-attachments/assets/6f50a593-f5da-409f-91f6-190347908f49">
