### PR TITLE
Add performance.mark/measure to runner

### DIFF
--- a/wasm-cli.js
+++ b/wasm-cli.js
@@ -29,6 +29,7 @@ testList = [
   "quicksort-wasm",
   "gcc-loops-wasm",
   "richards-wasm",
+  "sqlite3-wasm",
   "tfjs-wasm",
   "tfjs-wasm-simd",
   "argon2-wasm",
@@ -36,5 +37,5 @@ testList = [
   "8bitbench-wasm",
 ];
 
-// Re-use the full CLI runner, just with the subset of Wasm line items above.
+// Reuse the full CLI runner, just with the subset of Wasm line items above.
 load("./cli.js");


### PR DESCRIPTION
...which can help to profile only code which is actually measured, not the setup and driver.

Also some drive-by fixes: Add sqlite3-wasm to `wasm-cli.js` runner, fix typo, use `performance.now` for Wall time of line items.