### PR TITLE
simpler and more robust test server startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
         "prettier": "^2.8.3",
         "selenium-webdriver": "^4.8.0",
         "es-main":"^1.3.0",
-        "local-web-server": "^5.4.0"
+        "lws": "^4.2.0",
+        "lws-cors": "^4.2.1",
+        "lws-index": "^3.1.1",
+        "lws-log": "^3.0.0",
+        "lws-static": "^3.1.1"
     }
 }

--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -1,8 +1,13 @@
-// Simple local server
+// Simple server for local testing.
+
 import * as path from "path";
 import commandLineArgs from "command-line-args";
 import esMain from "es-main";
-import LocalWebServer from "local-web-server";
+import LocalWebServer from "lws";
+import "lws-cors";
+import "lws-index";
+import "lws-log";
+import "lws-static";
 
 const ROOT_DIR = path.join(process.cwd(), "./");
 
@@ -14,20 +19,35 @@ export default async function serve(port) {
         directory: ROOT_DIR,
         corsOpenerPolicy: "same-origin",
         corsEmbedderPolicy: "require-corp",
+        logFormat: "dev",
+        stack: ["lws-log", "lws-cors", "lws-static", "lws-index"],
     });
-    console.log(`Server started on http://localhost:${port}`);
+    await verifyStartup(ws, port);
+
     process.on("exit", () => ws.server.close());
+
     return {
         close() {
             ws.server.close();
-        }
+        },
     };
 }
 
+async function verifyStartup(ws, port) {
+    await new Promise((resolve, reject) => {
+        ws.server.on("listening", () => {
+            console.log(`Server started on http://localhost:${port}`);
+            resolve();
+        });
+        ws.server.on("error", (e) => {
+            console.error("Error while starting the server", e);
+            reject(e);
+        });
+    });
+}
+
 function main() {
-    const optionDefinitions = [
-        { name: "port", type: Number, defaultValue: 8010, description: "Set the test-server port, The default value is 8010." },
-    ];
+    const optionDefinitions = [{ name: "port", type: Number, defaultValue: 8010, description: "Set the test-server port, The default value is 8010." }];
     const options = commandLineArgs(optionDefinitions);
     serve(options.port);
 }


### PR DESCRIPTION
Using the latest changes from https://github.com/WebKit/Speedometer/pull/473

- Only depend on explicit lws package
- Explicitly await server startup instead

This should slightly improve test stability.