### PR TITLE
Index.html in the pathname should be optional

### DIFF
--- a/Dart/benchmark.js
+++ b/Dart/benchmark.js
@@ -269,7 +269,7 @@ class Benchmark {
     if (isInBrowser) {
       // In browsers, relative imports don't work since we are not in a module.
       // (`import.meta.url` is not defined.)
-      let pathname = location.pathname.match(/(.*)index\.html/)[1];
+      const pathname = location.pathname.match(/^(.*\/)(?:[^.]+(?:\.(?:[^\/]+))+)?$/)[1];
       this.dart2wasmJsModule = await import(location.origin + pathname + "./Dart/build/flute.dart2wasm.mjs");
     } else {
       // In shells, relative imports require different paths, so try with and


### PR DESCRIPTION
When fixing paths in the url for Dart-flute-wasm I neglected to handle the case where index.html is not in the URL. It should now be robust against any rename of index.html too.