### PR TITLE
Throw errors in cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,8 @@
 
 const isInBrowser = false;
 console = {
-    log: print
+    log: globalThis?.console?.log ?? print,
+    error: globalThis?.console?.error ?? print,
 }
 
 const isD8 = typeof Realm !== "undefined";
@@ -57,8 +58,9 @@ async function runJetStream() {
         await JetStream.initialize();
         await JetStream.start();
     } catch (e) {
-        console.log("JetStream3 failed: " + e);
-        console.log(e.stack);
+        console.error("JetStream3 failed: " + e);
+        console.error(e.stack);
+        throw e;
     }
 }
 runJetStream();


### PR DESCRIPTION
Currently the shells don't fail with an error exit code if the benchmark suite fails.

- Both the d8 and spidermonkey shells fail with a non-zero exit status on unhandled promise rejections.
- JSC currently only prints an error message but exits successfully

