### PR TITLE
date-format: Add result hashing to prevent DCE

### DIFF
--- a/SunSpider/date-format-tofte.js
+++ b/SunSpider/date-format-tofte.js
@@ -309,9 +309,16 @@ function run() {
 
 
 class Benchmark {
+    EXPECTED_RESULT_HASH = 439041101;
+
     runIteration() {
         this.resultHash = 0x1a2b3c4d;
         for (let i = 0; i < 8; ++i)
             this.resultHash ^= run();
+    }
+
+    validate() {
+        if (this.resultHash != this.EXPECTED_RESULT_HASH)
+            throw new Error(`Got unexpected result hash ${this.resultHash} instead of ${this.EXPECTED_RESULT_HASH}`)
     }
 }

--- a/SunSpider/date-format-tofte.js
+++ b/SunSpider/date-format-tofte.js
@@ -297,6 +297,7 @@ function run() {
         var shortFormat = date.formatDate("Y-m-d");
         var longFormat = date.formatDate("l, F d, Y g:i:s A");
         date.setTime(date.getTime() + 84266956);
+        console.log(shortFormat.charCodeAt(6) , shortFormat.charCodeAt(8), longFormat.charCodeAt(10) , longFormat.charCodeAt(11) )
         resultHash ^= shortFormat.charCodeAt(6) | shortFormat.charCodeAt(8) << 8;
         resultHash ^= longFormat.charCodeAt(10) << 16 | longFormat.charCodeAt(11) << 24;
     }

--- a/SunSpider/date-format-tofte.js
+++ b/SunSpider/date-format-tofte.js
@@ -291,21 +291,26 @@ Date.prototype.formatDate = function (input,time) {
 
 function run() {
     var date = new Date("1/1/2007 1:11:11");
+    var resultHash = 0x1a2b3c4d;
 
     for (i = 0; i < 500; ++i) {
         var shortFormat = date.formatDate("Y-m-d");
         var longFormat = date.formatDate("l, F d, Y g:i:s A");
         date.setTime(date.getTime() + 84266956);
+        resultHash ^= shortFormat.charCodeAt(6) | shortFormat.charCodeAt(8) << 8;
+        resultHash ^= longFormat.charCodeAt(10) << 16 | longFormat.charCodeAt(11) << 24;
     }
 
     // FIXME: Find a way to validate this test.
     // https://bugs.webkit.org/show_bug.cgi?id=114849
+    return resultHash;
 }
 
 
 class Benchmark {
     runIteration() {
+        this.resultHash = 0x1a2b3c4d;
         for (let i = 0; i < 8; ++i)
-            run();
+            this.resultHash ^= run();
     }
 }

--- a/SunSpider/date-format-tofte.js
+++ b/SunSpider/date-format-tofte.js
@@ -297,7 +297,7 @@ function run() {
         var shortFormat = date.formatDate("Y-m-d");
         var longFormat = date.formatDate("l, F d, Y g:i:s A");
         date.setTime(date.getTime() + 84266956);
-        console.log(shortFormat.charCodeAt(6) , shortFormat.charCodeAt(8), longFormat.charCodeAt(10) , longFormat.charCodeAt(11) )
+        // Assuming only ascii output.
         resultHash ^= shortFormat.charCodeAt(6) | shortFormat.charCodeAt(8) << 8;
         resultHash ^= longFormat.charCodeAt(10) << 16 | longFormat.charCodeAt(11) << 24;
     }

--- a/SunSpider/date-format-xparb.js
+++ b/SunSpider/date-format-xparb.js
@@ -416,6 +416,7 @@ function run() {
         var shortFormat = date.dateFormat("Y-m-d");
         var longFormat = date.dateFormat("l, F d, Y g:i:s A");
         date.setTime(date.getTime() + 84266956);
+        // Assuming only ascii output.
         resultHash ^= shortFormat.charCodeAt(6) | shortFormat.charCodeAt(8) << 8;
         resultHash ^= longFormat.charCodeAt(10) << 16 | longFormat.charCodeAt(11) << 24;
     }

--- a/SunSpider/date-format-xparb.js
+++ b/SunSpider/date-format-xparb.js
@@ -428,9 +428,16 @@ function run() {
 
 
 class Benchmark {
+    EXPECTED_RESULT_HASH = 439041101;
+
     runIteration() {
         this.resultHash = 0x1a2b3c4d;
         for (let i = 0; i < 8; ++i)
             this.resultHash ^= run();
+    }
+
+    validate() {
+        if (this.resultHash != this.EXPECTED_RESULT_HASH)
+            throw new Error(`Got unexpected result hash ${this.resultHash} instead of ${this.EXPECTED_RESULT_HASH}`)
     }
 }

--- a/SunSpider/date-format-xparb.js
+++ b/SunSpider/date-format-xparb.js
@@ -410,21 +410,26 @@ Date.patterns = {
 
 function run() {
     var date = new Date("1/1/2007 1:11:11");
+    var resultHash = 0x1a2b3c4d;
 
     for (i = 0; i < 4000; ++i) {
         var shortFormat = date.dateFormat("Y-m-d");
         var longFormat = date.dateFormat("l, F d, Y g:i:s A");
         date.setTime(date.getTime() + 84266956);
+        resultHash ^= shortFormat.charCodeAt(6) | shortFormat.charCodeAt(8) << 8;
+        resultHash ^= longFormat.charCodeAt(10) << 16 | longFormat.charCodeAt(11) << 24;
     }
 
     // FIXME: Find a way to validate this test.
     // https://bugs.webkit.org/show_bug.cgi?id=114849
+    return resultHash;
 }
 
 
 class Benchmark {
     runIteration() {
+        this.resultHash = 0x1a2b3c4d;
         for (let i = 0; i < 8; ++i)
-            run();
+            this.resultHash ^= run();
     }
 }


### PR DESCRIPTION
Dead code elimination could be used to bypass the date formatting in extreme cases.
Create a simple hash from the result strings to prevent this.