### PR TITLE
gbemu: Add basic canvas pixel hashing

### DIFF
--- a/Octane/gbemu-part1.js
+++ b/Octane/gbemu-part1.js
@@ -39,7 +39,11 @@ function runGameboy() {
     GameBoyAudioNode.run();
   }
 
+  var resultHash = gameboy.canvas.resultHash;
+
   resetGlobalVariables();
+
+  return resultHash;
 }
 
 function tearDownGameboy() {
@@ -56,7 +60,8 @@ var expectedGameboyStateStr =
 
 var GameBoyWindow = { };
 
-function GameBoyContext() {
+function GameBoyContext(canvas) {
+
   this.createBuffer = function() {
     return new Buffer();
   }
@@ -69,20 +74,21 @@ function GameBoyContext() {
   this.putImageData = function (buffer, x, y) {
     var sum = 0;
     for (var i = 0; i < buffer.data.length; i++) {
-      sum += i * buffer.data[i];
-      sum = sum % 1000;
+      sum ^= (i * buffer.data[i]) | 0;
     }
+    canvas.resultHash ^= sum;
   }
   this.drawImage = function () { }
 };
 
 function GameBoyCanvas() {
   this.getContext = function() {
-    return new GameBoyContext();
+    return new GameBoyContext(this);
   }
   this.width = 160;
   this.height = 144;
   this.style = { visibility: "visibile" };
+  this.resultHash = 0x1a2b3c4f;
 }
 
 function cout(message, colorIndex) {

--- a/Octane/gbemu-part2.js
+++ b/Octane/gbemu-part2.js
@@ -9783,6 +9783,6 @@ setupGameboy();
 
 class Benchmark {
     runIteration() {
-        runGameboy();
+        this.result = runGameboy();
     }
 }


### PR DESCRIPTION
Make sure we leak a hash of all "drawn" pixels from the canvas. Currently there isn't a proper side-effect and the whole canvas code could be DCE'd which is rather unrealistic.