### PR TITLE
Disable all BigInt tests except bigint-noble-ed25519 by default

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -631,6 +631,7 @@ class Benchmark {
         this.tags = new Set(plan.tags);
         this.iterations = getIterationCount(plan);
         this.isAsync = !!plan.isAsync;
+        this.disabledByDefault = !!plan.disabledByDefault;
         this.scripts = null;
         this._resourcesPromise = null;
         this._state = BenchmarkState.READY;
@@ -1879,6 +1880,7 @@ let BENCHMARKS = [
         worstCaseCount: 1,
         deterministicRandom: true,
         tags: ["BigIntNoble"],
+        disabledByDefault: true,
     }),
     new AsyncBenchmark({
         name: "bigint-noble-secp256k1",
@@ -1889,6 +1891,7 @@ let BENCHMARKS = [
         ],
         deterministicRandom: true,
         tags: ["BigIntNoble"],
+        disabledByDefault: true,
     }),
     new AsyncBenchmark({
         name: "bigint-noble-ed25519",
@@ -1912,6 +1915,7 @@ let BENCHMARKS = [
         worstCaseCount: 2,
         deterministicRandom: true,
         tags: ["BigIntMisc"],
+        disabledByDefault: true,
     }),
     new DefaultBenchmark({
         name: "bigint-bigdenary",
@@ -1922,6 +1926,7 @@ let BENCHMARKS = [
         iterations: 160,
         worstCaseCount: 16,
         tags: ["BigIntMisc"],
+        disabledByDefault: true,
     }),
     // Proxy
     new AsyncBenchmark({
@@ -2309,17 +2314,28 @@ for (const benchmark of BENCHMARKS) {
 
 this.JetStream = new Driver();
 
+function enableBenchmarks(benchmarks, forceEnable = false)
+{
+    for (let benchmark of benchmarks) {
+        if (!forceEnable && benchmark.disabledByDefault)
+            return;
+
+        JetStream.addBenchmark(benchmark);
+    }
+}
+
 function enableBenchmarksByName(name)
 {
     const benchmark = benchmarksByName.get(name);
 
-    if (benchmark)
-        JetStream.addBenchmark(benchmark);
-    else
+    if (!benchmark)
         throw new Error(`Couldn't find benchmark named "${name}"`);
+
+    // We only use this for test lists.
+    JetStream.addBenchmark(benchmark);
 }
 
-function enableBenchmarksByTag(tag)
+function enableBenchmarksByTag(tag, forceEnable = false)
 {
     const benchmarks = benchmarksByTag.get(tag);
 
@@ -2328,8 +2344,12 @@ function enableBenchmarksByTag(tag)
         throw new Error(`Couldn't find tag named: ${tag}.\n Choices are ${validTags}`);
     }
 
-    for (let benchmark of benchmarks)
+    for (const benchmark of benchmarks) {
+        if (!forceEnable && benchmark.disabledByDefault)
+            continue;
+
         JetStream.addBenchmark(benchmark);
+    }
 }
 
 function processTestList(testList)
@@ -2341,9 +2361,10 @@ function processTestList(testList)
     else
         benchmarkNames = testList.split(/[\s,]/);
 
+    const forceEnable = true;
     for (const name of benchmarkNames) {
         if (benchmarksByTag.has(name))
-            enableBenchmarksByTag(name);
+            enableBenchmarksByTag(name, forceEnable);
         else
             enableBenchmarksByName(name);
     }


### PR DESCRIPTION
We've decided we're only going to keep one BigInt test for now. bigint-noble-ed25519 is the remaining BigInt test enabled by default as it appears to do the most interesting things with BigInts. The rest are now disabled by default. They will run if they're passed via a test list but are otherwise not enabled.

To make this work there's a new property on `Benchmark`s/`plan`s that disables them by default.