### PR TITLE
Pass the blob URL for preloads in WasmEMCCBenchmark.

### DIFF
--- a/8bitbench/benchmark.js
+++ b/8bitbench/benchmark.js
@@ -1,4 +1,5 @@
 // Copyright 2025 the V8 project authors. All rights reserved.
+// Copyright 2025 Apple Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -34,6 +35,16 @@ function dumpFrame(vec) {
 
 class Benchmark {
   isInstantiated = false;
+  romBinary;
+
+  async init() {
+    if (isInBrowser) {
+      let response = await fetch(romBinary);
+      this.romBinary = new Int8Array(await response.arrayBuffer());
+    } else {
+      this.romBinary = new Int8Array(read(romBinary, "binary"));
+    }
+  }
 
   async runIteration() {
     if (!this.isInstantiated) {
@@ -41,7 +52,7 @@ class Benchmark {
       this.isInstantiated = true;
     }
 
-    wasm_bindgen.loadRom(Module.romBinary);
+    wasm_bindgen.loadRom(this.romBinary);
 
     const frameCount = 2 * 60;
     for (let i = 0; i < frameCount; ++i) {

--- a/8bitbench/benchmark.js
+++ b/8bitbench/benchmark.js
@@ -38,12 +38,8 @@ class Benchmark {
   romBinary;
 
   async init() {
-    if (isInBrowser) {
-      let response = await fetch(romBinary);
-      this.romBinary = new Int8Array(await response.arrayBuffer());
-    } else {
-      this.romBinary = new Int8Array(read(romBinary, "binary"));
-    }
+    Module.wasmBinary = await getBinary(wasmBinary);
+    this.romBinary = await getBinary(romBinary);
   }
 
   async runIteration() {

--- a/ARES-6/Babylon/benchmark.js
+++ b/ARES-6/Babylon/benchmark.js
@@ -31,10 +31,10 @@ class Benchmark {
         let sources = [];
 
         const files = [
-              [isInBrowser ? airBlob : "./ARES-6/Babylon/air-blob.js", {}]
-            , [isInBrowser ? basicBlob : "./ARES-6/Babylon/basic-blob.js", {}]
-            , [isInBrowser ? inspectorBlob : "./ARES-6/Babylon/inspector-blob.js", {}]
-            , [isInBrowser ? babylonBlob : "./ARES-6/Babylon/babylon-blob.js", {sourceType: "module"}]
+              [airBlob, {}]
+            , [basicBlob, {}]
+            , [inspectorBlob, {}]
+            , [babylonBlob, {sourceType: "module"}]
         ];
 
         for (let [file, options] of files) {

--- a/ARES-6/Babylon/benchmark.js
+++ b/ARES-6/Babylon/benchmark.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,8 +26,7 @@
 "use strict";
 
 class Benchmark {
-    constructor(verbose = 0)
-    {
+    async init(verbose = 0) {
         let sources = [];
 
         const files = [
@@ -37,23 +36,8 @@ class Benchmark {
             , [babylonBlob, {sourceType: "module"}]
         ];
 
-        for (let [file, options] of files) {
-            function appendSource(s) {
-                sources.push([file, s, options]);
-            }
-
-            let s;
-            if (isInBrowser) {
-                let request = new XMLHttpRequest();
-                request.open('GET', file, false);
-                request.send(null);
-                if (!request.responseText.length)
-                    throw new Error("Expect non-empty sources");
-                appendSource(request.responseText);
-            } else {
-                appendSource(read(file));
-            }
-        }
+        for (let [file, options] of files)
+            sources.push([file, await getString(file), options]);
 
         this.sources = sources;
     }

--- a/Dart/benchmark.js
+++ b/Dart/benchmark.js
@@ -261,20 +261,9 @@ class Benchmark {
   async init() {
     // The generated JavaScript code from dart2wasm is an ES module, which we
     // can only load with a dynamic import (since this file is not a module.)
-    // TODO: Support ES6 modules in the driver instead of this one-off solution.
-    // This probably requires a new `Benchmark` field called `modules` that
-    // is a map from module variable name (which will hold the resulting module
-    // namespace object) to relative module URL, which is resolved in the
-    // `preRunnerCode`, similar to this code here.
 
-    try {
-      this.dart2wasmJsModule = await import(jsModule);
-    } catch {
-      // In shells, relative imports require different paths, so try with and
-      // without the "./" prefix (e.g., JSC requires it).
-      if (!isInBrowser)
-        this.dart2wasmJsModule = await import(jsModule.slice("./".length))
-    }
+    Module.wasmBinary = await getBinary(wasmBinary);
+    this.dart2wasmJsModule = await dynamicImport(jsModule);
   }
 
   async runIteration() {

--- a/Dart/benchmark.js
+++ b/Dart/benchmark.js
@@ -266,19 +266,14 @@ class Benchmark {
     // is a map from module variable name (which will hold the resulting module
     // namespace object) to relative module URL, which is resolved in the
     // `preRunnerCode`, similar to this code here.
-    if (isInBrowser) {
-      // In browsers, relative imports don't work since we are not in a module.
-      // (`import.meta.url` is not defined.)
-      const pathname = location.pathname.match(/^(.*\/)(?:[^.]+(?:\.(?:[^\/]+))+)?$/)[1];
-      this.dart2wasmJsModule = await import(location.origin + pathname + "./Dart/build/flute.dart2wasm.mjs");
-    } else {
+
+    try {
+      this.dart2wasmJsModule = await import(jsModule);
+    } catch {
       // In shells, relative imports require different paths, so try with and
       // without the "./" prefix (e.g., JSC requires it).
-      try {
-        this.dart2wasmJsModule = await import("Dart/build/flute.dart2wasm.mjs");
-      } catch {
-        this.dart2wasmJsModule = await import("./Dart/build/flute.dart2wasm.mjs");
-      }
+      if (!isInBrowser)
+        this.dart2wasmJsModule = await import(jsModule.slice("./".length))
     }
   }
 

--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -1228,8 +1228,12 @@ class WasmEMCCBenchmark extends AsyncBenchmark {
                 }
             `;
 
-        for (let [ preloadKey, blobURLOrPath ] of this.preloads)
-            str += `await getBinary("${preloadKey}", "${blobURLOrPath}");\n`
+        for (let [ preloadKey, blobURLOrPath ] of this.preloads) {
+            if (preloadKey == "wasmBinary") {
+                str += `await getBinary("${preloadKey}", "${blobURLOrPath}");\n`
+                break;
+            }
+        }
 
         str += super.runnerCode;
 
@@ -2078,7 +2082,8 @@ let BENCHMARKS = [
             "./Dart/benchmark.js",
         ],
         preload: {
-            wasmBinary: "./Dart/build/flute.dart2wasm.wasm"
+            jsModule: "./Dart/build/flute.dart2wasm.mjs",
+            wasmBinary: "./Dart/build/flute.dart2wasm.wasm",
         },
         iterations: 15,
         worstCaseCount: 2,

--- a/code-load/code-first-load.js
+++ b/code-load/code-first-load.js
@@ -25,21 +25,8 @@
 
 let indirectEval = eval;
 class Benchmark {
-    constructor(iterations) {
-
-        let inspectorText;
-        if (isInBrowser) {
-            let request = new XMLHttpRequest();
-            request.open('GET', inspectorPayloadBlob, false);
-            request.send(null);
-            if (!request.responseText.length)
-                throw new Error("Expect non-empty sources");
-
-            inspectorText = request.responseText;
-        } else
-            inspectorText = readFile(inspectorPayloadBlob);
-
-        this.inspectorText = `let _____top_level_____ = ${Math.random()}; ${inspectorText}`;
+    async init() {
+        this.inspectorText = `let _____top_level_____ = ${Math.random()}; ${await getString(inspectorPayloadBlob)}`;
 
         this.index = 0;
     }

--- a/code-load/code-first-load.js
+++ b/code-load/code-first-load.js
@@ -37,7 +37,7 @@ class Benchmark {
 
             inspectorText = request.responseText;
         } else
-            inspectorText = readFile("./code-load/inspector-payload-minified.js");
+            inspectorText = readFile(inspectorPayloadBlob);
 
         this.inspectorText = `let _____top_level_____ = ${Math.random()}; ${inspectorText}`;
 

--- a/code-load/code-multi-load.js
+++ b/code-load/code-multi-load.js
@@ -25,20 +25,8 @@
 
 let indirectEval = eval;
 class Benchmark {
-    constructor(iterations) {
-
-        let inspectorText;
-        if (isInBrowser) {
-            let request = new XMLHttpRequest();
-            request.open('GET', inspectorPayloadBlob, false);
-            request.send(null);
-            if (!request.responseText.length)
-                throw new Error("Expect non-empty sources");
-            inspectorText = request.responseText;
-        } else
-            inspectorText = readFile(inspectorPayloadBlob);
-
-        this.inspectorText = `let _____top_level_____ = ${Math.random()}; ${inspectorText}`;
+    async init() {
+        this.inspectorText = `let _____top_level_____ = ${Math.random()}; ${await getString(inspectorPayloadBlob)}`;
         this.index = 0;
     }
 

--- a/code-load/code-multi-load.js
+++ b/code-load/code-multi-load.js
@@ -36,7 +36,7 @@ class Benchmark {
                 throw new Error("Expect non-empty sources");
             inspectorText = request.responseText;
         } else
-            inspectorText = readFile("./code-load/inspector-payload-minified.js");
+            inspectorText = readFile(inspectorPayloadBlob);
 
         this.inspectorText = `let _____top_level_____ = ${Math.random()}; ${inspectorText}`;
         this.index = 0;

--- a/sqlite3/benchmark.js
+++ b/sqlite3/benchmark.js
@@ -1,4 +1,5 @@
 // Copyright 2024 the V8 project authors. All rights reserved.
+// Copyright 2025 Apple Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -50,6 +51,10 @@ delete globalThis.FileSystemHandle;
 
 class Benchmark {
   sqlite3Module;
+
+  async init() {
+    Module.wasmBinary = await getBinary(wasmBinary);
+  }
 
   async runIteration() {
     if (!this.sqlite3Module) {

--- a/wasm/HashSet/benchmark.js
+++ b/wasm/HashSet/benchmark.js
@@ -1,8 +1,13 @@
 // Copyright 2025 the V8 project authors. All rights reserved.
+// Copyright 2025 Apple Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 class Benchmark {
+    async init() {
+        Module.wasmBinary = await getBinary(wasmBinary);
+    }
+
     async runIteration() {
         if (!Module._main)
             await setupModule(Module);

--- a/wasm/TSF/benchmark.js
+++ b/wasm/TSF/benchmark.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,6 +24,10 @@
 */
 
 class Benchmark {
+    async init() {
+        Module.wasmBinary = await getBinary(wasmBinary);
+    }
+
     async runIteration() {
         if (!Module._runIteration)
             await setupModule(Module);

--- a/wasm/argon2/benchmark.js
+++ b/wasm/argon2/benchmark.js
@@ -76,6 +76,10 @@ const version = 0x13;
 const saltLength = 12;
 
 class Benchmark {
+    async init() {
+        Module.wasmBinary = await getBinary(wasmBinary);
+    }
+
     async runIteration() {
         // Instantiate the Wasm module before the first run.
         if (!Module._argon2_hash) {

--- a/wasm/gcc-loops/benchmark.js
+++ b/wasm/gcc-loops/benchmark.js
@@ -1,8 +1,13 @@
 // Copyright 2025 the V8 project authors. All rights reserved.
+// Copyright 2025 Apple Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 class Benchmark {
+    async init() {
+        Module.wasmBinary = await getBinary(wasmBinary);
+    }
+
     async runIteration() {
         if (!Module._main)
             await setupModule(Module);

--- a/wasm/quicksort/benchmark.js
+++ b/wasm/quicksort/benchmark.js
@@ -1,8 +1,13 @@
 // Copyright 2025 the V8 project authors. All rights reserved.
+// Copyright 2025 Apple Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 class Benchmark {
+  async init() {
+    Module.wasmBinary = await getBinary(wasmBinary);
+  }
+
   async runIteration() {
     if (!Module._main)
       await setupModule(Module);

--- a/wasm/richards/benchmark.js
+++ b/wasm/richards/benchmark.js
@@ -1,8 +1,13 @@
 // Copyright 2025 the V8 project authors. All rights reserved.
+// Copyright 2025 Apple Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 class Benchmark {
+  async init() {
+    Module.wasmBinary = await getBinary(wasmBinary);
+  }
+
   async runIteration() {
     // Instantiate the Wasm module before the first run.
     if (!Module._setup)

--- a/wasm/zlib/benchmark.js
+++ b/wasm/zlib/benchmark.js
@@ -1,8 +1,13 @@
 // Copyright 2025 the V8 project authors. All rights reserved.
+// Copyright 2025 Apple Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 class Benchmark {
+  async init() {
+    Module.wasmBinary = await getBinary(wasmBinary);
+  }
+
   async runIteration() {
     if (!Module._compressFile)
       await setupModule(Module);


### PR DESCRIPTION
Right now we pass the original path when loading preloads for WasmEMCCBenchmark. This means we might skip the cache and fetch the content from the network again. We don't want to do this because it means the OS might spin down the CPU, which can punish running faster.

I also moved this logic to the `prerunCode` rather than adding it to the `runnerCode` since logically that makes more sense.

Lastly, have the preloads tuples contain the path for cli runs. This means we no longer have to duplicate the preload paths into the benchmark.js file.