### PR TITLE
ZLib should check for _compressFile rather than _main to see if the module has been instantiated

### DIFF
--- a/wasm/zlib/benchmark.js
+++ b/wasm/zlib/benchmark.js
@@ -4,7 +4,7 @@
 
 class Benchmark {
   async runIteration() {
-    if (!Module._main)
+    if (!Module._compressFile)
       await setupModule(Module);
 
     Module.FS.writeFile('input', Module.wasmBinary);


### PR DESCRIPTION
Since _main isn't exported by the module we end up recreating the instance/module on each iteration.