### PR TITLE
Fix accidental loading status clipping in wide windows

### DIFF
--- a/JetStream.css
+++ b/JetStream.css
@@ -224,7 +224,6 @@ a.button {
     color: transparent;
     background-image: linear-gradient(132deg, #96E5FF 0%, #96E5FF 2%, #86D9FF 42%, #8BDAFF 84%, #96E5FF 98%, #96E5FF 100%);
     -webkit-background-clip: text;
-    background-size: 1200px 100%;
     background-repeat: no-repeat;
     -webkit-touch-callout: none;
     -webkit-user-select: none;

--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -471,7 +471,7 @@ class Driver {
             window.addEventListener("error", (e) => this.pushError("driver startup", e.error));
         await this.prefetchResourcesForBrowser();
         await this.fetchResources();
-        this.prepareToRun();
+        //this.prepareToRun();
         this.isReady = true;
         if (isInBrowser) {
             globalThis.dispatchEvent(new Event("JetStreamReady"));
@@ -516,7 +516,7 @@ class Driver {
             promises.push(benchmark.fetchResources());
         await Promise.all(promises);
 
-        if (!isInBrowser)
+        if (true)
             return;
 
         const statusElement = document.getElementById("status");

--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -471,7 +471,7 @@ class Driver {
             window.addEventListener("error", (e) => this.pushError("driver startup", e.error));
         await this.prefetchResourcesForBrowser();
         await this.fetchResources();
-        //this.prepareToRun();
+        this.prepareToRun();
         this.isReady = true;
         if (isInBrowser) {
             globalThis.dispatchEvent(new Event("JetStreamReady"));
@@ -516,7 +516,7 @@ class Driver {
             promises.push(benchmark.fetchResources());
         await Promise.all(promises);
 
-        if (true)
+        if (!isInBrowser)
             return;
 
         const statusElement = document.getElementById("status");


### PR DESCRIPTION
Since the logo is a text-clipped gradient and the backouground size is preset, we sometimes don't render the loading text if the browser window is really larget.

Seems like we don't need the background-size at all, which fixes the probel.

<img width="1877" alt="Screenshot 2025-07-09 at 15 32 40" src="https://github.com/user-attachments/assets/da224e0a-14ea-49d8-bcd7-6d190776b7eb" />
