### PR TITLE
Cleanup of non-browser prefetch code

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -597,7 +597,6 @@ class Benchmark {
         this.disabledByDefault = !!plan.disabledByDefault;
         this.scripts = null;
         this.preloads = null;
-        this._resourcesPromise = null;
         this._state = BenchmarkState.READY;
     }
 


### PR DESCRIPTION
@kmiller68 and @camillobruni Could you take a look?

There were several problems (see also #86):
- The `fileLoader` singleton contained code for the browser, which was actually dead.
- `benchmark.fetchResources` was called twice in the CLI, once in `Driver.addBenchmark` and once again in `Driver.initialize`
- For several of the `Benchmark.prefetch*/retryPrefetch*/fetchResources` methods, it wasn't clear that they would only be called in the browser/non-browser setting, which also resulted in dead and unnecessarily complex code.

We can probably clean up more still, especially for the browser prefetching (see TODOs).