### PR TITLE
Add basic unittests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1695,9 +1695,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1695,9 +1695,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "test:spidermonkey": "node tests/run-shell.mjs --shell spidermonkey"
     },
     "devDependencies": {
+        "@actions/core": "^1.11.1",
         "@babel/core": "^7.21.3",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/plugin-proposal-decorators": "^7.21.0",
@@ -39,7 +40,6 @@
         "jsvu": "^2.5.1",
         "local-web-server": "^5.4.0",
         "prettier": "^2.8.3",
-        "selenium-webdriver": "^4.8.0",
-        "@actions/core": "^1.11.1"
+        "selenium-webdriver": "^4.8.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "test:spidermonkey": "node tests/run-shell.mjs --shell spidermonkey"
     },
     "devDependencies": {
-        "@actions/core": "^1.11.1",
         "@babel/core": "^7.21.3",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/plugin-proposal-decorators": "^7.21.0",
@@ -40,6 +39,7 @@
         "jsvu": "^2.5.1",
         "local-web-server": "^5.4.0",
         "prettier": "^2.8.3",
-        "selenium-webdriver": "^4.8.0"
+        "selenium-webdriver": "^4.8.0",
+        "@actions/core": "^1.11.1"
     }
 }

--- a/shell-config.js
+++ b/shell-config.js
@@ -23,17 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-load("./shell-config.js")
-load("./JetStreamDriver.js");
-
-async function runJetStream() {
-    try {
-        await JetStream.initialize();
-        await JetStream.start();
-    } catch (e) {
-        console.error("JetStream3 failed: " + e);
-        console.error(e.stack);
-        throw e;
-    }
+const isInBrowser = false;
+console = {
+    log: globalThis?.console?.log ?? print,
+    error: globalThis?.console?.error ?? print,
 }
-runJetStream();
+
+const isD8 = typeof Realm !== "undefined";
+if (isD8)
+    globalThis.readFile = read;
+const isSpiderMonkey = typeof newGlobal !== "undefined";
+if (isSpiderMonkey) {
+    globalThis.readFile = readRelativeToScript;
+    globalThis.arguments = scriptArgs;
+}
+
+if (typeof arguments !== "undefined" && arguments.length > 0)
+    testList = arguments.slice();
+if (typeof testList === "undefined")
+    testList = undefined;
+
+if (typeof testIterationCount === "undefined")
+    testIterationCount = undefined;
+
+if (typeof runMode !== "undefined" && runMode == "RAMification")
+    RAMification = true;
+else
+    RAMification = false;

--- a/tests/run-shell.mjs
+++ b/tests/run-shell.mjs
@@ -133,7 +133,7 @@ function sh(binary, args) {
 async function runTests() {
     const shellBinary = logGroup(`Installing JavaScript Shell: ${SHELL_NAME}`, testSetup);
     let success = true;
-    success &&= runTest("Run Unittests", () => sh(shellBinary, ["tests/unittests.js"]));
+    success &&= runTest("Run UnitTests", () => sh(shellBinary, ["tests/unittests.js"]));
     success &&= runTest("Run Complete Suite", () => sh(shellBinary, [CLI_PATH]));
     success &&= runTest("Run Single Suite", () => {
       const singleTestArgs = [...BASE_CLI_ARGS_WITH_OPTIONS, "proxy-mobx"];

--- a/tests/run-shell.mjs
+++ b/tests/run-shell.mjs
@@ -66,11 +66,13 @@ const SHELL_NAME = (function() {
 const FILE_PATH = fileURLToPath(import.meta.url);
 const SRC_DIR = path.dirname(path.dirname(FILE_PATH));
 const CLI_PATH = path.join(SRC_DIR, "cli.js");
+const UNIT_TEST_PATH = path.join(SRC_DIR, "tests", "unit-tests.js");
 
-const BASE_CLI_ARGS_WITH_OPTIONS = [CLI_PATH];
-if (SHELL_NAME != "spidermonkey")
-  BASE_CLI_ARGS_WITH_OPTIONS.push("--");
-Object.freeze(BASE_CLI_ARGS_WITH_OPTIONS);
+function convertCliArgs(cli, ...cliArgs) {
+  if (SHELL_NAME == "spidermonkey")
+    return [cli, ...cliArgs]
+  return [cli, "--", ...cliArgs];
+}
 
 const GITHUB_ACTIONS_OUTPUT = "GITHUB_ACTIONS_OUTPUT" in process.env;
 
@@ -133,11 +135,10 @@ function sh(binary, args) {
 async function runTests() {
     const shellBinary = logGroup(`Installing JavaScript Shell: ${SHELL_NAME}`, testSetup);
     let success = true;
-    success &&= runTest("Run UnitTests", () => sh(shellBinary, ["tests/unittests.js"]));
-    success &&= runTest("Run Complete Suite", () => sh(shellBinary, [CLI_PATH]));
+    success &&= runTest("Run UnitTests", () => sh(shellBinary, [UNIT_TEST_PATH]));
+    success &&= runTest("Run Complete Suite", () => sh(shellBinary, convertCliArgs(CLI_PATH)));
     success &&= runTest("Run Single Suite", () => {
-      const singleTestArgs = [...BASE_CLI_ARGS_WITH_OPTIONS, "proxy-mobx"];
-      sh(shellBinary, singleTestArgs);
+      sh(shellBinary, convertCliArgs(CLI_PATH, "proxy-mobx"));
     });
     if (!success) {
       process.exit(1)

--- a/tests/run-shell.mjs
+++ b/tests/run-shell.mjs
@@ -133,6 +133,7 @@ function sh(binary, args) {
 async function runTests() {
     const shellBinary = logGroup(`Installing JavaScript Shell: ${SHELL_NAME}`, testSetup);
     let success = true;
+    success &&= runTest("Run Unittests", () => sh(shellBinary, ["tests/unittests.js"]));
     success &&= runTest("Run Complete Suite", () => sh(shellBinary, [CLI_PATH]));
     success &&= runTest("Run Single Suite", () => {
       const singleTestArgs = [...BASE_CLI_ARGS_WITH_OPTIONS, "proxy-mobx"];

--- a/tests/unit-tests.js
+++ b/tests/unit-tests.js
@@ -1,0 +1,14 @@
+load("shell-config.js")
+load("JetStreamDriver.js");
+
+function assertTrue(condition, message) {
+  if (!condition) {
+    throw new Error(message || "Assertion failed");
+  }
+}
+
+(function testTagsAreStrings() {
+  for (const benchmark of BENCHMARKS) {
+    benchmark.tags.forEach(tag => assertTrue(typeof(tag) == "string"))
+  }
+})();


### PR DESCRIPTION
Prepare code to run basic unit tests:

- Add separate shell-config.js that can be shared between cli and unit tests
- Add basic first unit tests to check that all tags are strings