### PR TITLE
Run all disabled workloads in unittests

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -612,14 +612,22 @@ class Benchmark {
     constructor(plan)
     {
         this.plan = plan;
-        this.tags = new Set(plan.tags.map(each => each.toLowerCase()));
-        if (this.tags.size != plan.tags.length)
-            throw new Error(`${this.name} got duplicate tags: ${plan.tags.join()}`);
+        this.tags = this.processTags(plan.tags)
         this.iterations = getIterationCount(plan);
         this.isAsync = !!plan.isAsync;
         this.scripts = null;
         this.preloads = null;
         this._state = BenchmarkState.READY;
+    }
+
+    processTags(rawTags) {
+        const tags = new Set(rawTags.map(each => each.toLowerCase()));
+        if (tags.size != rawTags.length)
+            throw new Error(`${this.name} got duplicate tags: ${rawTags.join()}`);
+        tags.add("all");
+        if (!tags.has("default"))
+            tags.add("disabled");
+        return tags;
     }
 
     get name() { return this.plan.name; }
@@ -2184,22 +2192,23 @@ let BENCHMARKS = [
     })
 ];
 
-// LuaJSFight tests
-const luaJSFightTests = [
-    "hello_world"
-    , "list_search"
-    , "lists"
-    , "string_lists"
-];
-for (const test of luaJSFightTests) {
-    BENCHMARKS.push(new DefaultBenchmark({
-        name: `${test}-LJF`,
-        files: [
-            `./LuaJSFight/${test}.js`
-        ],
-        tags: ["LuaJSFight"],
-    }));
-}
+// FIXME: figure out what to do this these benchmarks.
+// // LuaJSFight tests
+// const luaJSFightTests = [
+//     "hello_world"
+//     , "list_search"
+//     , "lists"
+//     , "string_lists"
+// ];
+// for (const test of luaJSFightTests) {
+//     BENCHMARKS.push(new DefaultBenchmark({
+//         name: `${test}-LJF`,
+//         files: [
+//             `./LuaJSFight/${test}.js`
+//         ],
+//         tags: ["LuaJSFight"],
+//     }));
+// }
 
 // SunSpider tests
 const SUNSPIDER_TESTS = [
@@ -2263,8 +2272,6 @@ for (const benchmark of BENCHMARKS) {
     else
         benchmarksByName.set(name, benchmark);
     
-    benchmark.tags.add("all");
-
     for (const tag of benchmark.tags) {
         if (benchmarksByTag.has(tag))
             benchmarksByTag.get(tag).push(benchmark);

--- a/tests/unit-tests.js
+++ b/tests/unit-tests.js
@@ -19,9 +19,12 @@ function assertEquals(actual, expected, message) {
   }
 }
 
-(function testTagsAreStrings() {
+(function testTagsAreLowerCaseStrings() {
   for (const benchmark of BENCHMARKS) {
-    benchmark.tags.forEach(tag => assertTrue(typeof(tag) == "string"))
+    benchmark.tags.forEach(tag => {
+        assertTrue(typeof(tag) == "string");
+        assertTrue(tag == tag.toLowerCase());
+    })
   }
 })();
 
@@ -29,10 +32,12 @@ function assertEquals(actual, expected, message) {
 
 (function testTagsAll() {
   for (const benchmark of BENCHMARKS) {
-    assertTrue(benchmark.tags instanceof Set);
-    assertTrue(benchmark.tags.size > 0);
-    assertTrue(benchmark.tags.has("all"));
-    assertFalse(benchmark.tags.has("All"));
+    const tags = benchmark.tags;
+    assertTrue(tags instanceof Set);
+    assertTrue(tags.size > 0);
+    assertTrue(tags.has("all"));
+    assertFalse(tags.has("All"));
+    assertTrue(tags.has("default") || tags.has("disabled"));
   }
 })();
 


### PR DESCRIPTION
- Add "disabled" tag
- Move default tags processing to the Benchmark class
- Add more tags test
- Refactor unittest cli code a bit
- Change unittest order to get faster failing feedback (single test, disabled test, default suite)

- Disable broken LuaJSFight for now (we should likely just remove them)