### PR TITLE
Add validate method for async-fs and sync-fs

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -2394,7 +2394,7 @@ function processTestList(testList)
     for (let name of benchmarkNames) {
         name = name.toLowerCase();
         if (benchmarksByTag.has(name))
-            benchmarks.push(...findBenchmarksByTag(name));
+            benchmarks.concat(findBenchmarksByTag(name));
         else
             benchmarks.push(findBenchmarkByName(name));
     }

--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -2391,7 +2391,8 @@ function processTestList(testList)
     else
         benchmarkNames = testList.split(/[\s,]/);
 
-    for (const name of benchmarkNames) {
+    for (let name of benchmarkNames) {
+        name = name.toLowerCase();
         if (benchmarksByTag.has(name))
             benchmarks.push(...findBenchmarksByTag(name));
         else

--- a/generators/async-file-system.js
+++ b/generators/async-file-system.js
@@ -203,8 +203,9 @@ class Benchmark {
     }
 
     validate(iterations) {
-        if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
-            throw new Error(`Invalid total file count ${this.totalFileCount}`); 
+        const expectedFileCount = this.EXPECTED_FILE_COUNT * iterations;
+        if (this.totalFileCount != expectedFileCount)
+            throw new Error(`Invalid total file count ${this.totalFileCount}, expected ${expectedFileCount}.`);
         if (this.lastFileHash === undefined)
             throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }

--- a/generators/async-file-system.js
+++ b/generators/async-file-system.js
@@ -56,9 +56,13 @@ class File {
     set data(dataView) { this._data = dataView; }
 
     swapByteOrder() {
+        let hash = 0x1a2b3c4d;
         for (let i = 0; i < Math.floor(this.data.byteLength / 8) * 8; i += 8) {
-            this.data.setFloat64(i, this.data.getFloat64(i, isLittleEndian), !isLittleEndian);
+            const data = this.data.getFloat64(i, isLittleEndian);
+            this.data.setFloat64(i, data, !isLittleEndian);
+            hash ^= data | 0;
         }
+        return hash;
     }
 }
 
@@ -171,11 +175,17 @@ async function setupDirectory() {
 }
 
 class Benchmark {
+    EXPECTED_FILE_COUNT = 666;
+    EXPECTED_LAST_FILE_HASH = 1024076396;
+
+    totalFileCount = 0;
+    lastFileHash = 0;
+
     async runIteration() {
         const fs = await setupDirectory();
 
         for await (let { entry: file } of fs.forEachFileRecursively()) {
-            file.swapByteOrder();
+            this.lastFileHash = file.swapByteOrder();
         }
 
         for await (let { name, entry: dir } of fs.forEachDirectoryRecursively()) {
@@ -187,5 +197,16 @@ class Benchmark {
                 }
             }
         }
+
+        for await (let _ of fs.forEachFileRecursively()) {
+            this.totalFileCount++;
+        }
+    }
+
+    validate(iterations) {
+        if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
+            throw new Error(`Invalid total file count ${this.totalFileCount}`); 
+        if (this.lastFileHash != this.EXPECTED_LAST_FILE_HASH)
+            throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }
 }

--- a/generators/async-file-system.js
+++ b/generators/async-file-system.js
@@ -205,7 +205,7 @@ class Benchmark {
     validate(iterations) {
         if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
             throw new Error(`Invalid total file count ${this.totalFileCount}`); 
-        if (this.lastFileHash !== undefined)
+        if (this.lastFileHash === undefined)
             throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }
 }

--- a/generators/async-file-system.js
+++ b/generators/async-file-system.js
@@ -176,10 +176,9 @@ async function setupDirectory() {
 
 class Benchmark {
     EXPECTED_FILE_COUNT = 666;
-    EXPECTED_LAST_FILE_HASH = 1024076396;
 
     totalFileCount = 0;
-    lastFileHash = 0;
+    lastFileHash = undefined;
 
     async runIteration() {
         const fs = await setupDirectory();
@@ -206,7 +205,7 @@ class Benchmark {
     validate(iterations) {
         if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
             throw new Error(`Invalid total file count ${this.totalFileCount}`); 
-        if (this.lastFileHash != this.EXPECTED_LAST_FILE_HASH)
+        if (this.lastFileHash !== undefined)
             throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }
 }

--- a/generators/sync-file-system.js
+++ b/generators/sync-file-system.js
@@ -166,10 +166,9 @@ function setupDirectory() {
 
 class Benchmark {
     EXPECTED_FILE_COUNT = 411;
-    EXPECTED_LAST_FILE_HASH = 1042364057;
 
     totalFileCount = 0;
-    lastFileHash = 0;
+    lastFileHash = undefined;
 
     runIteration() {
         const fs = setupDirectory();
@@ -197,7 +196,7 @@ class Benchmark {
     validate(iterations) {
         if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
             throw new Error(`Invalid total file count ${this.totalFileCount}`); 
-        if (this.lastFileHash != this.EXPECTED_LAST_FILE_HASH)
+        if (this.lastFileHash !== undefined)
             throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }
 }

--- a/generators/sync-file-system.js
+++ b/generators/sync-file-system.js
@@ -53,9 +53,13 @@ class File {
     set data(dataView) { this._data = dataView; }
 
     swapByteOrder() {
+        let hash = 0x1a2b3c4d;
         for (let i = 0; i < Math.floor(this.data.byteLength / 8) * 8; i += 8) {
-            this.data.setFloat64(i, this.data.getFloat64(i, isLittleEndian), !isLittleEndian);
+            const data = this.data.getFloat64(i, isLittleEndian);
+            this.data.setFloat64(i, data, !isLittleEndian);
+            hash ^= data | 0;
         }
+        return hash;
     }
 }
 
@@ -161,11 +165,17 @@ function setupDirectory() {
 }
 
 class Benchmark {
+    EXPECTED_FILE_COUNT = 411;
+    EXPECTED_LAST_FILE_HASH = 1042364057;
+
+    totalFileCount = 0;
+    lastFileHash = 0;
+
     runIteration() {
         const fs = setupDirectory();
 
         for (let { entry: file } of fs.forEachFileRecursively()) {
-            file.swapByteOrder();
+            this.lastFileHash = file.swapByteOrder();
         }
 
         for (let { name, entry: dir } of fs.forEachDirectoryRecursively()) {
@@ -178,5 +188,16 @@ class Benchmark {
                 }
             }
         }
+
+        for (let _ of fs.forEachFileRecursively()) {
+            this.totalFileCount++;
+        }
+    }
+
+    validate(iterations) {
+        if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
+            throw new Error(`Invalid total file count ${this.totalFileCount}`); 
+        if (this.lastFileHash != this.EXPECTED_LAST_FILE_HASH)
+            throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }
 }

--- a/generators/sync-file-system.js
+++ b/generators/sync-file-system.js
@@ -196,7 +196,7 @@ class Benchmark {
     validate(iterations) {
         if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
             throw new Error(`Invalid total file count ${this.totalFileCount}`); 
-        if (this.lastFileHash !== undefined)
+        if (this.lastFileHash === undefined)
             throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }
 }

--- a/generators/sync-file-system.js
+++ b/generators/sync-file-system.js
@@ -194,8 +194,9 @@ class Benchmark {
     }
 
     validate(iterations) {
-        if (this.totalFileCount != this.EXPECTED_FILE_COUNT * iterations)
-            throw new Error(`Invalid total file count ${this.totalFileCount}`); 
+        const expectedFileCount = this.EXPECTED_FILE_COUNT * iterations;
+        if (this.totalFileCount != expectedFileCount)
+            throw new Error(`Invalid total file count ${this.totalFileCount}, expected ${expectedFileCount}.`);
         if (this.lastFileHash === undefined)
             throw new Error(`Invalid file hash: ${this.lastFileHash}`);
     }

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -103,7 +103,7 @@ async function testEnd2End(params) {
 
 async function benchmarkResults(driver) {
     logInfo("JetStream START");
-    await driver.manage().setTimeouts({ script: 60_000 });
+    await driver.manage().setTimeouts({ script: 2 * 60_000 });
     await driver.executeAsyncScript((callback) => {
         globalThis.JetStream.start();
         callback();

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -118,7 +118,7 @@ async function benchmarkResults(driver) {
 
 class JetStreamTestError extends Error {
     constructor(errors) {
-        super(`Tests failed: ${errors.map(e => e.name).join(", ")}`);
+        super(`Tests failed: ${errors.map(e => e.stack).join(", ")}`);
         this.errors = errors;
     }
 


### PR DESCRIPTION
Make sure we have global side-effects and validation of the final result.

Drive-by-fix:
- Convert testList items to lowerCase for better ergonomics
- Print error stack if we see remote failures in the end2end tests