### PR TITLE
Always run all test configurations even if there are failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         env:
             GITHUB_ACTIONS_OUTPUT: ""
         strategy:
+            fail-fast: false
             matrix:
                 browser: [chrome, firefox, jsc, safari, spidermonkey, v8]
         steps:


### PR DESCRIPTION
It's easier for development if we see which engines / browser fails and succeds and don't just cancel all test runs if the first one fails.