### PR TITLE
Fix benchmarksByTag with a custom test list. 

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -2430,7 +2430,7 @@ function processTestList(testList)
     for (let name of benchmarkNames) {
         name = name.toLowerCase();
         if (benchmarksByTag.has(name))
-            benchmarks.concat(findBenchmarksByTag(name));
+            benchmarks = benchmarks.concat(findBenchmarksByTag(name));
         else
             benchmarks.push(findBenchmarkByName(name));
     }


### PR DESCRIPTION
Array.prototype.concat returns a new array and doesn't modify the `this` one.