### PR TITLE
Set setStatus: null and monitorRunDependencies: null explicitly for w…

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -1271,27 +1271,12 @@ class WasmEMCCBenchmark extends AsyncBenchmark {
                 postRun: [],
                 noInitialRun: true,
                 print: print,
-                printErr: printErr,
-                setStatus: function(text) {
-                },
-                totalDependencies: 0,
-                monitorRunDependencies: function(left) {
-                    this.totalDependencies = Math.max(this.totalDependencies, left);
-                    Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
-                },
+                printErr: printErr
             };
 
             globalObject.Module = Module;
             ${super.prerunCode};
         `;
-
-        if (isSpiderMonkey) {
-            str += `
-                // Needed because SpiderMonkey shell doesn't have a setTimeout.
-                Module.setStatus = null;
-                Module.monitorRunDependencies = null;
-            `;
-        }
 
         return str;
     }
@@ -1413,14 +1398,7 @@ class WasmLegacyBenchmark extends Benchmark {
                 preRun: [],
                 postRun: [],
                 print: globalObject.print,
-                printErr: globalObject.print,
-                setStatus: function(text) {
-                },
-                totalDependencies: 0,
-                monitorRunDependencies: function(left) {
-                    this.totalDependencies = Math.max(this.totalDependencies, left);
-                    Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
-                }
+                printErr: globalObject.print
             };
             globalObject.Module = Module;
             `;
@@ -1450,9 +1428,6 @@ class WasmLegacyBenchmark extends Benchmark {
                     throw new Error;
                 };
             };
-
-            Module.setStatus = null;
-            Module.monitorRunDependencies = null;
 
             Promise.resolve(42).then(() => {
                 try {


### PR DESCRIPTION
…asm tests

emscripten generates the following code,

```
  if (Module["setStatus"]) {
    Module["setStatus"]("Running...");
    setTimeout(() => {
      setTimeout(() => Module["setStatus"](""), 1);
      doRun();
    }, 1);
  } else {
    doRun();
  }
```

And this code is ran in the first iteration of wasm benchmarks since it includes setup code. This causes a problem since it has artificially inserted setTimeout with 1ms.

1. It can insert 1ms wait time artificially. This is not so great since it reduces CPU pstate randomly, causing weird perf cliff depending on CPU's powner management instead of JS engine's quality.
2. The spec requires setTimeout to have some throttling mechanism. So we can hit some artificial large delay more than 1ms based on how many nestings we did before (https://webkit.org/blog/13083/speedometer-2-1/)

This patch explicitly sets setStatus and monitorRunDependencies to null so that we will not use this `setTimeout` code path generated by emscripten. This is already done for SpiderMonkey shell. So we expand it for the other engines as well.

Close #118