### PR TITLE
Add a new GroupedBenchmark that runs a series of benchmarks.

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -1124,10 +1124,10 @@ class Benchmark {
 class GroupedBenchmark extends Benchmark {
     constructor(plan, benchmarks) {
         super(plan);
-        assert(benchmarks.length);
+        console.assert(benchmarks.length);
         for (const benchmark of benchmarks) {
             // FIXME: Tags don't work for grouped tests anyway but if they did then this would be weird and probably wrong.
-            assert(benchmark.plan.tags.indexOf("Default") === -1, `Grouped benchmark sub-benchmarks shouldn't have the "Default" tag`, benchmark.tags);
+            console.assert(!benchmark.hasAnyTag("Default"), `Grouped benchmark sub-benchmarks shouldn't have the "Default" tag`, benchmark.tags);
         }
         benchmarks.sort((a, b) => a.name.toLowerCase() < b.name.toLowerCase() ? 1 : -1);
         this.benchmarks = benchmarks;

--- a/tests/unit-tests.js
+++ b/tests/unit-tests.js
@@ -86,8 +86,8 @@ function assertEquals(actual, expected, message) {
       assertTrue(typeof(name) == "string");
       // "Score" can only be part of allScores().
       assertFalse(name == "Score");
-      // Without running all values should be null.
-      assertEquals(value, null);
+      // Without running values should be either null (or 0 for GroupedBenchmark)
+      assertFalse(value)
     }
   }
 })();


### PR DESCRIPTION
Use this for all the SunSpider tests.

Grouped benchmarks just run each sub-benchmark in order then report those back. The score is the geomean of each sub-benchmarks analogous score e.g. the geomean of each sub-benchmark's First or Average scores. All the relevant prefetching is just forwarded to the sub-benchmarks

Only note is that `subScores` re-computes everything every time because it's called before the benchmark runs. Also, tags don't seem to work for the sub benchmarks. This didn't seem important enough to fix right now but we should maybe consider in the future. 