### PR TITLE
Only expose a console copy in the realm

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -629,7 +629,8 @@ class ShellScripts extends Scripts {
         } else
             globalObject = runString("");
 
-        // Expose console copy in the realm.
+        // Expose console copy in the realm so we don't accidentally modify
+        // the original object.
         globalObject.console = Object.assign({}, console);
         globalObject.self = globalObject;
         globalObject.top = {

--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -629,7 +629,8 @@ class ShellScripts extends Scripts {
         } else
             globalObject = runString("");
 
-        globalObject.console = console;
+        // Expose console copy in the realm.
+        globalObject.console = Object.assiugn({}, console);
         globalObject.self = globalObject;
         globalObject.top = {
             currentResolve,

--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -630,7 +630,7 @@ class ShellScripts extends Scripts {
             globalObject = runString("");
 
         // Expose console copy in the realm.
-        globalObject.console = Object.assiugn({}, console);
+        globalObject.console = Object.assign({}, console);
         globalObject.self = globalObject;
         globalObject.top = {
             currentResolve,


### PR DESCRIPTION
... to avoid accidentally overriding methods on the default console method.
Something that just happened on the new typescript workload #117 .