### PR TITLE
Kotlin-compose: do not access isD8 global

### DIFF
--- a/Kotlin-compose/build.log
+++ b/Kotlin-compose/build.log
@@ -1,4 +1,4 @@
-Built on 2025-08-08 16:11:09+02:00
+Built on 2025-08-14 12:27:42+02:00
 Cloning into 'compose-multiplatform'...
 84dad4d3f6 Use custom skiko (0.9.4.3) to fix the FinalizationRegistry API usage for web targets
 Copying generated files into build/

--- a/Kotlin-compose/build.sh
+++ b/Kotlin-compose/build.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 
 # Cleanup old files.
 rm -rf build/
+rm -rf compose-multiplatform/
 
 BUILD_LOG="$(realpath build.log)"
 echo -e "Built on $(date --rfc-3339=seconds)" | tee "$BUILD_LOG"
@@ -15,6 +16,10 @@ echo -e "Built on $(date --rfc-3339=seconds)" | tee "$BUILD_LOG"
 git clone -b ok/jetstream3_hotfix https://github.com/JetBrains/compose-multiplatform.git |& tee -a "$BUILD_LOG"
 pushd compose-multiplatform/
 git log -1 --oneline | tee -a "$BUILD_LOG"
+# Do not read `isD8` in the main function which decides whether to run eagerly.
+# Instead, just patch that out statically.
+# TODO: Upstream that fix to the compose-multiplatform repo.
+git apply ../empty-main-function.patch | tee -a "$BUILD_LOG"
 # FIXME: Use stable 2.3 Kotlin/Wasm toolchain, once available around Sep 2025.
 git apply ../use-beta-toolchain.patch | tee -a "$BUILD_LOG"
 pushd benchmarks/multiplatform

--- a/Kotlin-compose/build/compose-benchmarks-benchmarks.uninstantiated.mjs
+++ b/Kotlin-compose/build/compose-benchmarks-benchmarks.uninstantiated.mjs
@@ -172,7 +172,6 @@ export async function instantiate(imports={}, runInitializer=true) {
         'org.w3c.dom.matches_$external_prop_getter' : (_this) => _this.matches,
         'org.w3c.dom.protocol_$external_prop_getter' : (_this) => _this.protocol,
         'org.w3c.dom.hostname_$external_prop_getter' : (_this) => _this.hostname,
-        'org.w3c.dom.search_$external_prop_getter' : (_this) => _this.search,
         'org.w3c.dom.getData_$external_fun' : (_this, p0) => _this.getData(p0),
         'org.w3c.dom.setData_$external_fun' : (_this, p0, p1) => _this.setData(p0, p1),
         'org.w3c.dom.language_$external_prop_getter' : (_this) => _this.language,
@@ -198,8 +197,6 @@ export async function instantiate(imports={}, runInitializer=true) {
         'org.w3c.dom.reason_$external_prop_getter' : (_this) => _this.reason,
         'org.w3c.dom.parsing.DOMParser_$external_fun' : () => new DOMParser(),
         'org.w3c.dom.parsing.parseFromString_$external_fun' : (_this, p0, p1) => _this.parseFromString(p0, p1),
-        'org.w3c.dom.url.URLSearchParams_$external_fun' : (p0, isDefault0) => new URLSearchParams(isDefault0 ? undefined : p0, ),
-        'org.w3c.dom.url.get_$external_fun' : (_this, p0) => _this.get(p0),
         'org.w3c.fetch.status_$external_prop_getter' : (_this) => _this.status,
         'org.w3c.fetch.ok_$external_prop_getter' : (_this) => _this.ok,
         'org.w3c.fetch.statusText_$external_prop_getter' : (_this) => _this.statusText,
@@ -358,7 +355,6 @@ export async function instantiate(imports={}, runInitializer=true) {
         'io.ktor.client.utils.makeJsNew' : (ctor) => new ctor(),
         'io.ktor.client.utils.setObjectField' : (obj, name, value) => obj[name]=value,
         'io.ktor.client.utils.toJsArrayImpl' : (x) => new Uint8Array(x),
-        'isD8env' : () => typeof isD8 !== 'undefined',
         'runGC' : () => { (typeof gc === 'function')? gc() : console.log('Manual GC is not available. Ensure that the browser was started with the appropriate flags.') }
     }
     

--- a/Kotlin-compose/empty-main-function.patch
+++ b/Kotlin-compose/empty-main-function.patch
@@ -1,0 +1,39 @@
+diff --git a/benchmarks/multiplatform/benchmarks/src/wasmJsMain/kotlin/main.wasmJs.kt b/benchmarks/multiplatform/benchmarks/src/wasmJsMain/kotlin/main.wasmJs.kt
+index d796d88975..f2c9e48eda 100644
+--- a/benchmarks/multiplatform/benchmarks/src/wasmJsMain/kotlin/main.wasmJs.kt
++++ b/benchmarks/multiplatform/benchmarks/src/wasmJsMain/kotlin/main.wasmJs.kt
+@@ -8,11 +8,6 @@ import kotlin.js.Promise
+ val jsOne = 1.toJsNumber()
+ 
+ fun main(args: Array<String>) {
+-    if (isD8env().toBoolean()) {
+-        mainD8(args)
+-    } else {
+-        mainBrowser()
+-    }
+ }
+ 
+ fun mainBrowser() {
+@@ -37,15 +32,6 @@ fun mainBrowser() {
+     }
+ }
+ 
+-
+-// Currently, the initialization can't be adjusted to avoid calling the fun main, but
+-// we don't want use the default fun main, because Jetstream3 requires running the workloads separately / independently of each other.
+-// Also, they require that a benchmark completes before the function exists, which is not possible with if they just call fun main.
+-// Therefore, they'll rely on fun customLaunch, which returns a Promise (can be awaited for).
+-fun mainD8(args: Array<String>) {
+-    println("mainD8 is intentionally doing nothing. Read the comments in main.wasmJs.kt")
+-}
+-
+ private val basicConfigForD8 = Config(
+     // Using only SIMPLE mode, because VSYNC_EMULATION calls delay(...),
+     // which is implemented via setTimeout on web targets.
+@@ -85,6 +71,3 @@ fun d8BenchmarksRunner(args: String): Promise<JsAny?> {
+         jsOne
+     }
+ }
+-
+-private fun isD8env(): JsBoolean =
+-    js("typeof isD8 !== 'undefined'")


### PR DESCRIPTION
Doesn't change behavior / performance characteristics, since we previously set the global `isD8 = false`, but let's be on the safe side / remove access to that global.