### PR TITLE
Disable HashSet-wasm

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -1989,7 +1989,9 @@ let BENCHMARKS = [
             wasmBinary: "./wasm/HashSet/build/HashSet.wasm",
         },
         iterations: 50,
-        tags: ["Default", "Wasm"],
+        // No longer run by-default: We have more realistic Wasm workloads by
+        // now, and it was over-incentivizing inlining.
+        tags: ["Wasm"],
     }),
     new WasmEMCCBenchmark({
         name: "tsf-wasm",


### PR DESCRIPTION
We had discussed removing this workload a couple of months ago, but wanted to wait for more Wasm workloads to land. Now we can, I think. Disabling this also lowers the Wasm proportion of the total score.

Reasons: It's not realistic at all (it basically inserts elements in a HashSet ~8000 times; the two `add` instantiations account for >75% of the CPU samples), over-incentivizes inlining, and we have better workloads now. E.g., if we care about general datastructures implemented in Wasm, the sqlite workload is much larger, comes from an upstream benchmark suite, and exercises more diverse code. 

We could also completely remove instead of disabling it, but I went for the conservative option for now.

We could also remove `gcc-loops-wasm` and `quicksort-wasm`, which are also quite microbenchmarky.

WDYT? @kmiller68 @eqrion @iainireland 
1. Disabling this fine? Remove it altogether?
2. How about `gcc-loops-wasm` and `quicksort-wasm`?