### PR TITLE
Stop running tfjs benchmarks by default

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -2209,7 +2209,7 @@ let BENCHMARKS = [
         },
         async: true,
         deterministicRandom: true,
-        tags: ["Default", "Wasm"],
+        tags: ["Wasm"],
     }),
     new WasmLegacyBenchmark({
         name: "tfjs-wasm-simd",
@@ -2229,7 +2229,7 @@ let BENCHMARKS = [
         },
         async: true,
         deterministicRandom: true,
-        tags: ["Default", "Wasm"],
+        tags: ["Wasm"],
     }),
     new WasmEMCCBenchmark({
         name: "argon2-wasm",


### PR DESCRIPTION
The desire is retiring these benchmarks, and it is not updated to the newer Wasm benchmark metrics. This patch disables them by default.