### PR TITLE
Support custom benchmark arguments

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -740,9 +740,16 @@ class Benchmark {
         return tags.some((tag) => this.tags.has(tag.toLowerCase()));
     }
 
+    get benchmarkArguments() {
+        return {
+            ...this.plan.arguments,
+            iterationCount: this.iterations,
+        };
+    }
+
     get runnerCode() {
         return `{
-            const benchmark = new Benchmark(${this.iterations});
+            const benchmark = new Benchmark(${JSON.stringify(this.benchmarkArguments)});
             const results = [];
             const benchmarkName = "${this.name}";
 
@@ -1404,7 +1411,7 @@ class WSLBenchmark extends Benchmark {
 
     get runnerCode() {
         return `{
-            const benchmark = new Benchmark();
+            const benchmark = new Benchmark(${JSON.stringify(this.benchmarkArguments)});
             const benchmarkName = "${this.name}";
 
             const results = [];

--- a/RexBench/benchmark.js
+++ b/RexBench/benchmark.js
@@ -25,7 +25,7 @@
 "use strict";
 
 class Benchmark {
-    constructor(verbose = 0)
+    constructor({verbose = 0})
     {
         this._verbose = verbose;
     }


### PR DESCRIPTION
For some benchmarks its easier to configure certain properties directly from the benchmark config.
See https://github.com/WebKit/JetStream/pull/143 which has different assertion values depending on which sources are used.