### PR TITLE
Add JetStreamParams

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -42,46 +42,7 @@ globalThis.startDelay ??= undefined;
 globalThis.shouldReport ??= false;
 globalThis.prefetchResources ??= true;
 
-function getIntParam(urlParams, key) {
-    const rawValue = urlParams.get(key);
-    const value = parseInt(rawValue);
-    if (value <= 0)
-        throw new Error(`Expected positive value for ${key}, but got ${rawValue}`);
-    return value;
-}
-
-function getBoolParam(urlParams, key) {
-    const rawValue = urlParams.get(key).toLowerCase()
-    return !(rawValue === "false" || rawValue === "0")
- }
-
-function getTestListParam(urlParams, key) {
-    if (globalThis.testList?.length)
-        throw new Error(`Overriding previous testList=${globalThis.testList.join()} with ${key} url-parameter.`);
-    return urlParams.getAll(key);
-}
-
-if (typeof(URLSearchParams) !== "undefined") {
-    const urlParameters = new URLSearchParams(window.location.search);
-    if (urlParameters.has("report"))
-        globalThis.shouldReport = urlParameters.get("report").toLowerCase() == "true";
-    if (urlParameters.has("startDelay"))
-        globalThis.startDelay = getIntParam(urlParameters, "startDelay");
-    if (globalThis.shouldReport && !globalThis.startDelay)
-        globalThis.startDelay = 4000;
-    if (urlParameters.has("tag"))
-        globalThis.testList = getTestListParam(urlParameters, "tag");
-    if (urlParameters.has("test"))
-        globalThis.testList = getTestListParam(urlParameters, "test");
-    if (urlParameters.has("iterationCount"))
-        globalThis.testIterationCount = getIntParam(urlParameters, "iterationCount");
-    if (urlParameters.has("worstCaseCount"))
-        globalThis.testWorstCaseCount = getIntParam(urlParameters, "worstCaseCount");
-    if (urlParameters.has("prefetchResources"))
-        globalThis.prefetchResources = getBoolParam(urlParameters, "prefetchResources");
-}
-
-if (!globalThis.prefetchResources)
+if (!JetStreamParams.prefetchResources)
     console.warn("Disabling resource prefetching!");
 
 // Used for the promise representing the current benchmark run.

--- a/cli.js
+++ b/cli.js
@@ -21,48 +21,109 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ */
 
-load("./shell-config.js")
+load("./shell-config.js");
 
-const cliFlags = { __proto__: null };
+const CLI_PARAMS = {
+  __proto__: null,
+  help: { help: "Print this help message.", param: "help" },
+  "iteration-count": {
+    help: "Set the default iteration count.",
+    param: "testIterationCount",
+  },
+  "worst-case-count": {
+    help: "Set the default worst-case count.",
+    param: "testWorstCaseCount",
+  },
+  "dump-json-results": {
+    help: "Print summary json to the console.",
+    param: "dumpJSONResults",
+  },
+  "dump-test-list": {
+    help: "Print test list instead of running.",
+    param: "dumpTestList",
+  },
+  ramification: {
+    help: "Enable ramification support. See RAMification.py for more details.",
+    param: "RAMification",
+  },
+  "no-prefetch": {
+    help: "Do not prefetch resources. Will add network overhead to measurements!",
+    param: "prefetchResources",
+  },
+  test: {
+    help: "Run a specific test or comma-separated list of tests.",
+    param: "test",
+  },
+  tag: {
+    help: "Run tests with a specific tag or comma-separated list of tags.",
+    param: "tag",
+  },
+  "start-automatically": {
+    help: "Start the benchmark automatically.",
+    param: "startAutomatically",
+  },
+  "developer-mode": { help: "Enable developer mode.", param: "developerMode" },
+  report: { help: "Report results to a server.", param: "shouldReport" },
+  "start-delay": {
+    help: "Delay before starting the benchmark.",
+    param: "startDelay",
+  },
+  "custom-pre-iteration-code": {
+    help: "Custom code to run before each iteration.",
+    param: "customPreIterationCode",
+  },
+  "custom-post-iteration-code": {
+    help: "Custom code to run after each iteration.",
+    param: "customPostIterationCode",
+  },
+};
+
+const cliParams = new Map();
 const cliArgs = [];
+
 if (globalThis.arguments?.length) {
-    for (const argument of globalThis.arguments)
-        if (argument.startsWith("--")) {
-            const parts = argument.split("=");
-            cliFlags[parts[0].toLowerCase()] = parts.slice(1).join("=");
-        } else
-            cliArgs.push(argument);
+  for (const argument of globalThis.arguments) {
+    if (argument.startsWith("--")) {
+      parseCliFlag(argument);
+    } else {
+      cliArgs.push(argument);
+    }
+  }
 }
 
-function getIntFlag(flags, flag) {
-    if (!(flag in flags))
-        return undefined;
-    const rawValue = flags[flag];
-    const value = parseInt(rawValue);
-    if (value <= 0)
-        throw new Error(`Expected positive value for ${flag}, but got ${rawValue}`);
-    return value;
+function parseCliFlag(argument) {
+    const parts = argument.slice(2).split("=");
+    const flagName = parts[0];
+    if (!(flagName in CLI_PARAMS)) {
+        const message =`Unknown flag: '--${flagName}'`;
+        help(message);
+        throw Error(message);
+    }
+    let value = parts.slice(1).join("=");
+    if (flagName === "no-prefetch") value = "false";
+    else if (value === "") value = "true";
+    cliParams.set(CLI_PARAMS[flagName].param, value);
 }
 
-if ("--iteration-count" in cliFlags)
-    globalThis.testIterationCount = getIntFlag(cliFlags, "--iteration-count");
-if ("--worst-case-count" in cliFlags)
-    globalThis.testWorstCaseCount = getIntFlag(cliFlags, "--worst-case-count");
-if ("--dump-json-results" in cliFlags)
-    globalThis.dumpJSONResults = true;
-if (typeof runMode !== "undefined" && runMode == "RAMification")
-    globalThis.RAMification = true;
-if ("--ramification" in cliFlags)
-    globalThis.RAMification = true;
-if ("--no-prefetch" in cliFlags)
-    globalThis.prefetchResources = false;
-if (cliArgs.length)
-    globalThis.testList = cliArgs;
+
+if (cliArgs.length) {
+    let tests = cliParams.has("test") ? cliParams.get("tests").split(",") : []
+    tests = tests.concat(cliArgs);
+    cliParams.set("test", tests.join(","));
+}
+
+if (cliParams.size) 
+    globalThis.JetStreamParamsSource = cliParams;
+
+load("./params.js");
 
 
 async function runJetStream() {
+    if (JetStreamParams !== DefaultJetStreamParams) {
+        console.warn(`Using non standard params: ${JSON.stringify(JetStreamParams, null, 2)}`)
+    }
     try {
         await JetStream.initialize();
         await JetStream.start();
@@ -75,31 +136,37 @@ async function runJetStream() {
 
 load("./JetStreamDriver.js");
 
-if ("--help" in cliFlags) {
-    console.log("JetStream Driver Help");
+function help(message=undefined) {
+    if (message)
+        console.log(message);
+    else
+        console.log("JetStream Driver Help");
     console.log("");
 
     console.log("Options:");
-    console.log("   --iteration-count:   Set the default iteration count.");
-    console.log("   --worst-case-count:  Set the default worst-case count");
-    console.log("   --dump-json-results: Print summary json to the console.");
-    console.log("   --dump-test-list:    Print test list instead of running.");
-    console.log("   --ramification:      Enable ramification support. See RAMification.py for more details.");
-    console.log("   --no-prefetch:       Do not prefetch resources. Will add network overhead to measurements!");
+    for (const [flag, { help }] of Object.entries(CLI_PARAMS))
+        console.log(`    --${flag.padEnd(20)} ${help}`);
     console.log("");
 
-    console.log("Available tags:");
-    const tagNames = Array.from(benchmarksByTag.keys()).sort();
-    for (const tagName of tagNames)
-        console.log("  ", tagName);
-    console.log("");
+    
+    if (typeof benchmarksByTag !== "undefined") {
+        console.log("Available tags:");
+        const tagNames = Array.from(benchmarksByTag.keys()).sort();
+        for (const tagName of tagNames) console.log("  ", tagName);
+        console.log("");
+    }
 
-    console.log("Available tests:");
-    const benchmarkNames = BENCHMARKS.map(b => b.name).sort();
-    for (const benchmark of benchmarkNames)
-        console.log("  ", benchmark);
-} else if ("--dump-test-list" in cliFlags) {
-    JetStream.dumpTestList();
+    if (typeof BENCHMARKS !== "undefined") {
+        console.log("Available tests:");
+        const benchmarkNames = BENCHMARKS.map((b) => b.name).sort();
+        for (const benchmark of benchmarkNames) console.log("  ", benchmark);
+    }
+}
+
+if (cliParams.has("help")) {
+    help();
+} else if (cliParams.has("dumpTestList")) {
+  JetStream.dumpTestList();
 } else {
-    runJetStream();
+  runJetStream();
 }

--- a/cli.js
+++ b/cli.js
@@ -121,7 +121,7 @@ load("./params.js");
 
 
 async function runJetStream() {
-    if (JetStreamParams !== DefaultJetStreamParams) {
+    if (!JetStreamParams.isDefault) {
         console.warn(`Using non standard params: ${JSON.stringify(JetStreamParams, null, 2)}`)
     }
     try {

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     const isInBrowser = true;
     const isD8 = false;
     const isSpiderMonkey = false;
+    globalThis.JetStreamParamsSource = new URLSearchParams(globalThis?.location?.search);
     globalThis.allIsGood = true;
     window.onerror = function(e) {
         if (e == "Script error.") {
@@ -65,6 +66,7 @@
     }
     </script>
 
+    <script src="params.js"></script>
     <script src="JetStreamDriver.js"></script>
 
 </head>

--- a/params.js
+++ b/params.js
@@ -1,0 +1,167 @@
+"use strict";
+
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+export class Params {
+  // Enable a detailed developer menu to change the current Params.
+  developerMode = false;
+  startAutomatically = false;
+
+  developerMode 
+    constructor(searchParams = undefined) {
+        if (searchParams)
+            this._copyFromSearchParams(searchParams);
+        if (!this.developerMode) {
+            Object.freeze(this.viewport);
+            Object.freeze(this);
+        }
+    }
+
+    _parseInt(value, errorMessage) {
+        const number = Number(value);
+        if (!Number.isInteger(number) && errorMessage)
+            throw new Error(`Invalid ${errorMessage} param: '${value}', expected int.`);
+        return parseInt(number);
+    }
+
+    _copyFromSearchParams(searchParams) {
+        this.viewport = this._parseViewport(searchParams);
+
+        const unused = Array.from(searchParams.keys());
+        if (unused.length > 0)
+            console.error("Got unused search params", unused);
+    }
+
+    _parseBooleanParam(searchParams, paramKey) {
+        if (!searchParams.has(paramKey))
+            return false;
+        searchParams.delete(paramKey);
+        return true;
+    }
+
+    _parseIntParam(searchParams, paramKey, minValue) {
+        if (!searchParams.has(paramKey))
+            return defaultParams[paramKey];
+
+        const parsedValue = this._parseInt(searchParams.get(paramKey), "waitBeforeSync");
+        if (parsedValue < minValue)
+            throw new Error(`Invalid ${paramKey} param: '${parsedValue}', value must be >= ${minValue}.`);
+        searchParams.delete(paramKey);
+        return parsedValue;
+    }
+
+    _parseSuites(searchParams) {
+        if (searchParams.has("suite") || searchParams.has("suites")) {
+            if (searchParams.has("suite") && searchParams.has("suites"))
+                throw new Error("Params 'suite' and 'suites' can not be used together.");
+            const value = searchParams.get("suite") || searchParams.get("suites");
+            const suites = value.split(",");
+            if (suites.length === 0)
+                throw new Error("No suites selected");
+            searchParams.delete("suite");
+            searchParams.delete("suites");
+            return suites;
+        }
+        return defaultParams.suites;
+    }
+
+    _parseTags(searchParams) {
+        if (!searchParams.has("tags"))
+            return defaultParams.tags;
+        if (this.suites.length)
+            throw new Error("'suites' and 'tags' cannot be used together.");
+        const tags = searchParams.get("tags").split(",");
+        searchParams.delete("tags");
+        return tags;
+    }
+
+    _parseEnumParam(searchParams, paramKey, enumArray) {
+        if (!searchParams.has(paramKey))
+            return defaultParams[paramKey];
+        const value = searchParams.get(paramKey);
+        if (!enumArray.includes(value))
+            throw new Error(`Got invalid ${paramKey}: '${value}', choices are ${enumArray}`);
+        searchParams.delete(paramKey);
+        return value;
+    }
+
+    _parseShuffleSeed(searchParams) {
+        if (!searchParams.has("shuffleSeed"))
+            return defaultParams.shuffleSeed;
+        let shuffleSeed = searchParams.get("shuffleSeed");
+        if (shuffleSeed !== "off") {
+            if (shuffleSeed === "generate") {
+                shuffleSeed = Math.floor((Math.random() * 1) << 16);
+                console.log(`Generated a random suite order seed: ${shuffleSeed}`);
+            } else {
+                shuffleSeed = parseInt(shuffleSeed);
+            }
+            if (!Number.isInteger(shuffleSeed))
+                throw new Error(`Invalid shuffle seed: '${shuffleSeed}', must be either 'off', 'generate' or an integer.`);
+        }
+        searchParams.delete("shuffleSeed");
+        return shuffleSeed;
+    }
+
+
+    toCompleteSearchParamsObject() {
+        return this.toSearchParamsObject(false);
+    }
+
+    toSearchParamsObject(filter = true) {
+        const rawUrlParams = { __proto__: null };
+        for (const [key, value] of Object.entries(this)) {
+            // Skip over default values.
+            if (filter && value === defaultParams[key])
+                continue;
+            rawUrlParams[key] = value;
+        }
+
+        if (this.viewport.width !== defaultParams.viewport.width || this.viewport.height !== defaultParams.viewport.height)
+            rawUrlParams.viewport = `${this.viewport.width}x${this.viewport.height}`;
+
+        if (this.suites.length) {
+            rawUrlParams.suites = this.suites.join(",");
+        } else if (this.tags.length) {
+            if (!(this.tags.length === 1 && this.tags[0] === "default"))
+                rawUrlParams.tags = this.tags.join(",");
+        } else {
+            rawUrlParams.suites = "";
+        }
+
+        return new URLSearchParams(rawUrlParams);
+    }
+
+    toSearchParams() {
+        return this.toSearchParamsObject().toString();
+    }
+}
+
+export const defaultParams = new Params();
+
+let maybeCustomParams = defaultParams;
+export const params = maybeCustomParams;

--- a/params.js
+++ b/params.js
@@ -131,6 +131,9 @@ class Params {
         return parsedValue;
     }
 
+    get isDefault() {
+      return this === DefaultJetStreamParams;
+    }
 }
 
 const DefaultJetStreamParams = new Params();

--- a/params.js
+++ b/params.js
@@ -26,7 +26,7 @@
 */
 
 
-export class Params {
+class JetStreamParams {
   // Enable a detailed developer menu to change the current Params.
   developerMode = false;
   startAutomatically = false;
@@ -161,7 +161,7 @@ export class Params {
     }
 }
 
-export const defaultParams = new Params();
+export const defaultParams = new JetStreamParams();
 
 let maybeCustomParams = defaultParams;
 export const params = maybeCustomParams;


### PR DESCRIPTION
- Copy params.js from Speedometer
- Implement more uniform params parsing for browser (URLSearchParams) and cli (Map from parsed arguments)
- Acces params/settings via global JetStreamParams
- Expose both JetStreamParams and DefaultJetStreamParams making it east to see if we're running with non-default params