### PR TITLE
Add prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,10 @@
+# Ignore all subdirs
+*/*
 node_modules
-**/dist
-package-lock.json
+packages.json
 
-# Un-ignore top-level files                                                                                     │
-!/*   
+# Un-ignore top-level files
+!/*
 
 # For now exclude all existing workloads
 **/*.html
@@ -11,4 +12,7 @@ package-lock.json
 
 !**/benchmark.js
 !**/src/*
-!**/build/*
+
+# Ignore generated and third-party files
+*/**/build/
+*/third_party/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+node_modules
+**/dist
+package-lock.json
+
+# Un-ignore top-level files                                                                                     │
+!/*   
+
+# For now exclude all existing workloads
+**/*.html
+**/*.js
+
+!**/benchmark.js
+!**/src/*
+!**/build/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ package-lock.json
 dist
 build
 *bundle*.js
+third_party
 
 /Octane/*
 /ARES-6/*
@@ -15,7 +16,11 @@ build
 /SeaMonster
 /WSL
 /worker/bomb-subtests
-wasm/dotnet/build-*
+/wasm/dotnet/build-*
+/wasm/tfjs-model-*
+/simple/*
+/generators/*
+/threejs/*
 
 # Ignore everything in RexBench, then selectively un-ignore.
 /RexBench/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,9 +15,12 @@ build
 /SeaMonster
 /WSL
 /worker/bomb-subtests
+wasm/dotnet/build-*
 
+# Ignore everything in RexBench, then selectively un-ignore.
 /RexBench/*
-!/RexBench/benchmark.js
+!/RexBench/*/
+/RexBench/*/*
 !/RexBench/*/benchmark.js
 
 !benchmark.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,18 +1,25 @@
-# Ignore all subdirs
-*/*
+.*
 node_modules
-packages.json
+package-lock.json
+dist
+build
+*bundle*.js
 
-# Un-ignore top-level files
-!/*
+/Octane/*
+/ARES-6/*
+/cdjs/*
+/8bitbench/*
+/class-fields/*
+/code-load/*
+/SunSpider
+/SeaMonster
+/WSL
+/worker/bomb-subtests
 
-# For now exclude all existing workloads
-**/*.html
-**/*.js
+/RexBench/*
+!/RexBench/benchmark.js
+!/RexBench/*/benchmark.js
 
-!**/benchmark.js
-!**/src/*
-
-# Ignore generated and third-party files
-*/**/build/
-*/third_party/
+!benchmark.js
+!*/benchmark.js
+!/**/*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+    "arrowParens": "always",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "htmlWhitespaceSensitivity": "css",
+    "printWidth": 250,
+    "semi": true,
+    "singleQuote": false,
+    "tabWidth": 4,
+    "trailingComma": "es5",
+    "useTabs": false
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
     "bracketSameLine": false,
     "bracketSpacing": true,
     "htmlWhitespaceSensitivity": "css",
-    "printWidth": 250,
+    "printWidth": 100,
     "semi": true,
     "singleQuote": false,
     "tabWidth": 4,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "http-server": "^14.1.1",
                 "jsvu": "^2.5.1",
                 "local-web-server": "^5.4.0",
-                "prettier": "^2.8.3",
+                "prettier": "^2.8.8",
                 "selenium-webdriver": "^4.35.0"
             },
             "engines": {
@@ -4923,6 +4923,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "prettier": "bin-prettier.js"
             },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "http-server": "^14.1.1",
         "jsvu": "^2.5.1",
         "local-web-server": "^5.4.0",
-        "prettier": "^2.8.3",
+        "prettier": "^2.8.8",
         "selenium-webdriver": "^4.35.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "compress": "node utils/compress.mjs",
         "lint:check": "eslint **/*.{js,mjs,jsx,ts,tsx}",
         "pretty:check": "prettier --check ./",
+        "pretty:format": "prettier --write ./",
         "format:check": "npm run pretty:check && npm run lint:check",
         "test:chrome": "node tests/run.mjs --browser chrome",
         "test:firefox": "node tests/run.mjs --browser firefox",

--- a/web-tooling-benchmark/src/acorn.mjs
+++ b/web-tooling-benchmark/src/acorn.mjs
@@ -40,7 +40,11 @@ const payloads = [
   },
 ];
 
-export function runTest(fileData) {
+export function runTest(
+  fileData
+
+
+) {
   const testData = payloads.map(({ name, options }) => ({
     payload: fileData[name],
     name: name,


### PR DESCRIPTION
This PR copies over the prettier config from Speedometer.

Note that I didn't implement the dual prettier + eslint approach, I always found that annoying (we need to duplicate the ignore files) and slow. 

In Speedometer this was introduced to more closely adhere to WebKit's style guide which I always found a bit problematic. I personally introduced a few bugs due to the no-braces for single block statements, so I'd be more than happy to loosen this requirement and go with the prettier defaults for sake of simplicity.

- Single block statements are on the same line
- Braces are required to force a new line for block statements

Beyond that I presonally don't care too much about code formatting, if there is an easy way to get closer to WebKit I'm fine.