### PR TITLE
Fix testIterationCount and testWorstCaseCount params

### DIFF
--- a/params.js
+++ b/params.js
@@ -73,8 +73,8 @@ class Params {
         for (const paramKey of ["tag", "tags", "test", "tests"])
             this.testList = this._parseTestListParam(sourceParams, paramKey);
 
-        this.testIterationCount = this._parseIntParam(sourceParams, "iterationCount", 1);
-        this.testWorstCaseCount = this._parseIntParam(sourceParams, "worstCaseCount", 1);
+        this.testIterationCount = this._parseIntParam(sourceParams, "testIterationCount", 1);
+        this.testWorstCaseCount = this._parseIntParam(sourceParams, "testWorstCaseCount", 1);
 
         const unused = Array.from(sourceParams.keys());
         if (unused.length > 0)
@@ -128,7 +128,7 @@ class Params {
         const number = Number(value);
         if (!Number.isInteger(number) && errorMessage)
             throw new Error(`Invalid ${errorMessage} param: '${value}', expected int.`);
-        return parseInt(number);
+        return number;
     }
 
     get isDefault() {


### PR DESCRIPTION
These params were using the names `iterationCount` and `worstCaseCount`, which are names not used in the code and which therefore result in unexpected behavior in various cases. For example, the cli flags `--iteration-count` and `--worst-case-count` were being totally ignored, and the `DefaultJetStreamParams` fallback behavior in `_parseIntParam` was looking up a nonexistent key.

cc @eqrion 