### PR TITLE
Support multiple comma separate tests in URL params

### DIFF
--- a/params.js
+++ b/params.js
@@ -78,8 +78,9 @@ class Params {
         if (this.report && !this.startDelay)
             this.startDelay = 4000;
 
-        for (const paramKey of ["tag", "tags", "test", "tests"])
+        for (const paramKey of ["tag", "tags", "test", "tests"]) {
             this.testList = this._parseTestListParam(sourceParams, paramKey);
+        }
 
         this.testIterationCount = this._parseIntParam(sourceParams, "iterationCount", 1);
         this.testWorstCaseCount = this._parseIntParam(sourceParams, "worstCaseCount", 1);
@@ -101,9 +102,11 @@ class Params {
             // fallback for cli sourceParams which is just a Map;
             testList = sourceParams.get(key).split(",");
         }
+        testList = testList.map(each => each.trim());
         sourceParams.delete(key);
-        if (this.testList.length > 0 && testList.length > 0)
+        if (this.testList.length > 0 && testList.length > 0) {
             throw new Error(`Overriding previous testList='${this.testList.join()}' with ${key} url-parameter.`);
+        }
         return testList;
     }
 

--- a/tests/run-browser.mjs
+++ b/tests/run-browser.mjs
@@ -61,6 +61,7 @@ async function runTests() {
     let success = true;
     try {
         success &&= await runEnd2EndTest("Run Single Suite", { test: "proxy-mobx" });
+        success &&= await runEnd2EndTest("Run Multiple Suites", { test: "prismjs-startup-es6,postcss-wtb" });
         success &&= await runEnd2EndTest("Run Tag No Prefetch",  { tag: "proxy", prefetchResources: "false" });
         success &&= await runEnd2EndTest("Run Disabled Suite", { tag: "disabled" });
         success &&= await runEnd2EndTest("Run Default Suite");


### PR DESCRIPTION
This was already supported on the command line but not in the URL params.