### PR TITLE
Disable transformersjs-whisper-wasm by default.

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -2542,7 +2542,7 @@ let BENCHMARKS = [
         iterations: 5,
         worstCaseCount: 1,
         allowUtf16: true,
-        tags: ["default", "Wasm", "transformersjs"],
+        tags: ["Wasm", "transformersjs"],
     }),
     new WasmLegacyBenchmark({
         name: "tfjs-wasm",


### PR DESCRIPTION
Whisper is a much more diverse workload in comparison to Bert but has some notable downsides. In particular, the model is much bigger and its overall memory footprint is much higher. This causes memory issues on iOS and seems to be related to a relatively high jetsam rate there.

Whisper also takes much longer to run than Bert. So getting rid of the longer workload speeds up the benchmark overall.