### PR TITLE
CLI summary label is clearer as Overall instead of Total

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -302,11 +302,11 @@ class Driver {
             }
         }
 
-        const totalScore = geomeanScore(allScores);
-        console.assert(totalScore > 0, `Invalid total score: ${totalScore}`);
+        const overallScore = geomeanScore(allScores);
+        console.assert(overallScore > 0, `Invalid total score: ${overallScore}`);
 
         if (isInBrowser) {
-            let summaryHtml = `<div class="score">${uiFriendlyScore(totalScore)}</div>
+            let summaryHtml = `<div class="score">${uiFriendlyScore(overallScore)}</div>
                     <label>Score</label>`;
             summaryHtml += `<div class="benchmark benchmark-done">`;
             for (let [category, scores] of categoryScores) {
@@ -329,20 +329,20 @@ class Driver {
             summaryElement.onclick = displayCategoryScores;
             statusElement.innerHTML = "";
         } else if (!JetStreamParams.dumpJSONResults) {
-            console.log("Total:");
+            console.log("Overall:");
             for (let [category, scores] of categoryScores) {
                 console.log(
-                    shellFriendlyLabel(`Total ${category}-Score`),
+                    shellFriendlyLabel(`Overall ${category}-Score`),
                     shellFriendlyScore(geomeanScore(scores)));
             }
             for (let [category, times] of categoryTimes) {
                 console.log(
-                    shellFriendlyLabel(`Total ${category}-Time`),
+                    shellFriendlyLabel(`Overall ${category}-Time`),
                     shellFriendlyDuration(geomeanScore(times)));
             }
             console.log("");
-            console.log(shellFriendlyLabel("Total Score"), shellFriendlyScore(totalScore));
-            console.log(shellFriendlyLabel("Total Time"), shellFriendlyDuration(totalTime));
+            console.log(shellFriendlyLabel("Overall Score"), shellFriendlyScore(overallScore));
+            console.log(shellFriendlyLabel("Overall Wall-Time"), shellFriendlyDuration(totalTime));
             console.log("");
         }
 
@@ -835,8 +835,8 @@ class Benchmark {
 
     allTimes() {
         const allTimes = this.subTimes();
-        allTimes["Wall"] = this.wallTime;
         allTimes["Total"] = this.totalTime;
+        allTimes["Wall"] = this.wallTime;
         return allTimes;
     }
 


### PR DESCRIPTION
Right now the CLI summary reports its metrics as "Total". I assumed at first glace this meant sum of all the categories. Since that's what the "Total-time" metric is reporting. If the label was "Overall", I think this would be more obvious. The last "Total Time" is now "Overall Wall-Time" to be more consistent with the line items' equivalent report.

I also reordered the line item "Total-time" to be before "Wall-Time" because I find that to be a slightly more intuitive order.

Before this change:
```
Running 8bitbench-wasm:
8bitbench-wasm First-Score                      23.66 pts
8bitbench-wasm Worst-Score                      31.79 pts
8bitbench-wasm Average-Score                    32.19 pts
8bitbench-wasm Score                            28.93 pts
8bitbench-wasm First-Time                      211.36 ms
8bitbench-wasm Worst-Time                      157.26 ms
8bitbench-wasm Average-Time                    155.35 ms
8bitbench-wasm Wall-Time                      2390.92 ms
8bitbench-wasm Total-Time                      523.97 ms

Total:
Total First-Score                              164.07 pts
Total Worst-Score                              306.75 pts
Total Average-Score                            427.19 pts
Total Stdlib-Score                              13.10 pts
Total MainRun-Score                              2.89 pts
Total First-Time                                31.58 ms
Total Worst-Time                                16.97 ms
Total Average-Time                              12.16 ms
Total Stdlib-Time                              381.82 ms
Total MainRun-Time                            1732.12 ms

Total Score                                    254.28 pts
Total Time                                    93008.80 ms
```

After:
```
Running 8bitbench-wasm:
8bitbench-wasm First-Score                      23.14 pts
8bitbench-wasm Worst-Score                      31.58 pts
8bitbench-wasm Average-Score                    32.05 pts
8bitbench-wasm Score                            28.61 pts
8bitbench-wasm First-Time                      216.06 ms
8bitbench-wasm Worst-Time                      158.35 ms
8bitbench-wasm Average-Time                    155.98 ms
8bitbench-wasm Total-Time                      530.39 ms
8bitbench-wasm Wall-Time                      2404.08 ms

Overall:
Overall First-Score                            171.40 pts
Overall Worst-Score                            330.65 pts
Overall Average-Score                          444.21 pts
Overall Stdlib-Score                            16.04 pts
Overall MainRun-Score                            2.80 pts
Overall First-Time                              30.24 ms
Overall Worst-Time                              15.70 ms
Overall Average-Time                            11.68 ms
Overall Stdlib-Time                            311.64 ms
Overall MainRun-Time                          1785.38 ms

Overall Score                                  268.03 pts
Overall Wall-Time                             87146.46 ms
```