### PR TITLE
Push up the inner loop counts for the doxbee tests.

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -2109,14 +2109,18 @@ let BENCHMARKS = [
         files: [
             "./simple/doxbee-promise.js",
         ],
-        tags: ["default",  "js", "promise", "Simple"],
+        iterations: 80,
+        worstCaseCount: 3,
+        tags: ["default",  "js", "promise", "Simple", "Doxbee"],
     }),
     new AsyncBenchmark({
         name: "doxbee-async",
         files: [
             "./simple/doxbee-async.js",
         ],
-        tags: ["default", "js", "Simple"],
+        iterations: 80,
+        worstCaseCount: 3,
+        tags: ["default", "js", "async", "Simple", "Doxbee"],
     }),
     // SeaMonster
     new DefaultBenchmark({

--- a/simple/doxbee-async.js
+++ b/simple/doxbee-async.js
@@ -170,9 +170,10 @@ const doxbee = require("../lib/doxbee-async");
 
 globalThis.Benchmark = class {
   runIteration() {
-    const promises = new Array(10_000);
+    const innerIterations = 25_000;
+    const promises = new Array(innerIterations);
 
-    for (var i = 0; i < 10_000; i++)
+    for (var i = 0; i < innerIterations; i++)
       promises[i] = doxbee(i, "foo");
 
     return Promise.all(promises);

--- a/simple/doxbee-promise.js
+++ b/simple/doxbee-promise.js
@@ -190,9 +190,10 @@ const doxbee = require("../lib/doxbee-promises");
 
 globalThis.Benchmark = class {
   runIteration() {
-    const promises = new Array(10_000);
+    const innerIterations = 20_000;
+    const promises = new Array(innerIterations);
 
-    for (var i = 0; i < 10_000; i++)
+    for (var i = 0; i < innerIterations; i++)
       promises[i] = doxbee(i, "foo");
 
     return Promise.all(promises);


### PR DESCRIPTION
Right now they're quite small and the tests finish in only a few ms. We'd like our tests to run for at least 10ms. After this change the average time in V8, which is the faster browser on this test, runs in about 12/14 ms for async/promise respectively on my M2 Pro Mac.

I also lowered the iteration count to keep the total time for these tests down. From looking at samples they both have a relatively small code set and tier up by the 3-4th iteration. Additionally 80 iterations seems to be long enough to catch the existing worst cases.