### PR TITLE
Reduce Kotlin-compose-wasm iteration count

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -2489,8 +2489,8 @@ let BENCHMARKS = [
             inputFontItalic: "./Kotlin-compose/build/jetbrainsmono_italic.ttf",
             inputFontRegular: "./Kotlin-compose/build/jetbrainsmono_regular.ttf"
         },
-        iterations: 15,
-        worstCaseCount: 2,
+        iterations: 5,
+        worstCaseCount: 1,
         tags: ["default", "Wasm"],
     }),
     new AsyncBenchmark({


### PR DESCRIPTION
Kotlin-compose-wasm is the longest running test in JS3 by a pretty wide margin. However after the first few iterations almost all code is in the most optimizing compiler in the respective engines.

This change reduces the iterations to 5 and sets adjusts the worst case count accordingly.