### PR TITLE
Shells should send console.warn and error to stderr

### DIFF
--- a/utils/shell-config.js
+++ b/utils/shell-config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@ const isInBrowser = false;
 if (typeof console == "undefined")
     console = {};
 
-console.debug ??= (...args) => console.log("Debug:", ...args);
+console.debug ??= (...args) => printErr("Debug: " + args.join(" "));
 console.log ??= (...args) => print(args.join(" "));
 console.warn ??= (...args) => printErr("Warn: " + args.join(" "));
 console.error ??= (...args) => printErr("Error: " + args.join(" "));


### PR DESCRIPTION
Right now they go to stdout, which makes running with json-dumping less effective since we `warn` the subset of tests being run.