### PR TITLE
Avoid new Date in doxbee benchmarks

### DIFF
--- a/simple/doxbee-async.js
+++ b/simple/doxbee-async.js
@@ -49,7 +49,6 @@ module.exports = async function doxbee(stream, idOrPath) {
     const previousId = file ? file.version : null;
     const version = {
       userAccountId: fakes.userAccount.id,
-      date: {},
       blobId: blobId,
       creatorId: fakes.userAccount.id,
       previousId: previousId

--- a/simple/doxbee-promise.js
+++ b/simple/doxbee-promise.js
@@ -55,7 +55,6 @@ module.exports = function doxbee(stream, idOrPath) {
       const previousId = file ? file.version : null;
       version = {
         userAccountId: fakes.userAccount.id,
-        date: {},
         blobId: blobId,
         creatorId: fakes.userAccount.id,
         previousId: previousId


### PR DESCRIPTION
Both benchmarks seem to spend quite a bit of time in `new Date()` and extracting file names from the `idOrPath` variable. The date is never really accessed which makes this a bit a weird pattern to have such a high weight.

- Remove `new Date()` for `version`
- Use `lastIndexOf` in one of the two benchmarks to get a bit diversity

This seems to move the scores up on all engines – happy to discuss this.