### PR TITLE
Make sure numBytes are integer

### DIFF
--- a/generators/async-file-system.js
+++ b/generators/async-file-system.js
@@ -38,7 +38,7 @@ const isLittleEndian = computeIsLittleEndian();
 async function *randomFileContents() {
     let counter = 1;
     while(true) {
-        const numBytes = ((counter * 1192.18851371) % 2056);
+        const numBytes = (((counter * 1192.18851371) | 0) % 2056);
         counter++;
         let result = new ArrayBuffer(numBytes);
         let view = new Uint8Array(result);

--- a/generators/sync-file-system.js
+++ b/generators/sync-file-system.js
@@ -38,7 +38,7 @@ const isLittleEndian = computeIsLittleEndian();
 function *randomFileContents() {
     let counter = 1;
     while(true) {
-        const numBytes = ((counter * 1192.18851371) % 2056);
+        const numBytes = (((counter * 1192.18851371) | 0) % 2056);
         counter++;
         let result = new ArrayBuffer(numBytes);
         let view = new Uint8Array(result);


### PR DESCRIPTION
It is hard to imagine that using floating-point numbers for numBytes in the wild, which is changed in 6215add877ab. This patch ensures that numBytes are integers.