### PR TITLE
StartupBenchmark should create sources lazily

### DIFF
--- a/babylonjs/benchmark/startup.js
+++ b/babylonjs/benchmark/startup.js
@@ -26,7 +26,6 @@
 // console.log = () => {};
 
 class Benchmark extends StartupBenchmark {
-  iteration = 0;
 
   constructor({iterationCount, expectedCacheCommentCount}) {
     super({
@@ -36,10 +35,11 @@ class Benchmark extends StartupBenchmark {
     });
   }
 
-  runIteration() {
-    const sourceCode = this.iterationSourceCodes[this.iteration];
+  runIteration(iteration) {
+    // super.prepareForNextIteration() sets this up for us.
+    const sourceCode = this.currentIterationSourceCode;
     if (!sourceCode)
-      throw new Error(`Could not find source for iteration ${this.iteration}`);
+      throw new Error(`Could not find source for iteration ${iteration}`);
     // Module in sourceCode it assigned to the ClassStartupTest variable.
     let BabylonJSBenchmark;
 
@@ -57,10 +57,9 @@ class Benchmark extends StartupBenchmark {
     // const loadTime = runStart - initStart;
     // const runTime = end - runStart;
     // For local debugging:
-    // print(`Iteration ${this.iteration}:`);
+    // print(`Iteration ${iteration}:`);
     // print(`  Load time: ${loadTime.toFixed(2)}ms`);
     // print(`  Render time: ${runTime.toFixed(2)}ms`);
-    this.iteration++;
   }
 
   validateIteration(lastResult) {

--- a/jsdom-d3-startup/benchmark.js
+++ b/jsdom-d3-startup/benchmark.js
@@ -33,7 +33,6 @@ globalThis.clearTimeout = () => { };
 class Benchmark extends StartupBenchmark {
     lastResult;
     totalHash = 0xdeadbeef;
-    currentIteration = 0;
 
     constructor({iterationCount}) {
         super({
@@ -52,10 +51,11 @@ class Benchmark extends StartupBenchmark {
         this.usData = JSON.parse(this.usDataJsonString);
     }
 
-    runIteration() {
-        let iterationSourceCode = this.iterationSourceCodes[this.currentIteration];
+    runIteration(iteration) {
+        // super.prepareForNextIteration() sets this up for us.
+        let iterationSourceCode = this.currentIterationSourceCode;
         if (!iterationSourceCode)
-            throw new Error(`Could not find source for iteration ${this.currentIteration}`);
+            throw new Error(`Could not find source for iteration ${iteration}`);
         // Module in sourceCode it assigned to the ReactRenderTest variable.
         let D3Test;
         eval(iterationSourceCode);
@@ -63,7 +63,6 @@ class Benchmark extends StartupBenchmark {
         const htmlHash = this.quickHash(html);
         this.lastResult = { html, htmlHash };
         this.totalHash ^= this.lastResult.htmlHash;
-        this.currentIteration++;
     }
 
     validate() {

--- a/mobx/benchmark.js
+++ b/mobx/benchmark.js
@@ -37,9 +37,10 @@ class Benchmark extends StartupBenchmark {
   }
 
   runIteration(iteration) {
-    // Module is loaded into PrismJSBenchmark
+    // Module is loaded into MobXBenchmark
     let MobXBenchmark;
-    eval(this.iterationSourceCodes[iteration]);
+    // super.prepareForNextIteration() sets this up for us.
+    eval(this.currentIterationSourceCode);
     this.lastResult = MobXBenchmark.runTest();
   }
 

--- a/prismjs/benchmark.js
+++ b/prismjs/benchmark.js
@@ -65,7 +65,8 @@ class Benchmark extends StartupBenchmark {
   runIteration(iteration) {
     // Module is loaded into PrismJSBenchmark
     let PrismJSBenchmark;
-    eval(this.iterationSourceCodes[iteration]);
+    // super.prepareForNextIteration() sets this up for us.
+    eval(this.currentIterationSourceCode);
     this.lastResult = PrismJSBenchmark.runTest(this.samples);
 
     for (const result of this.lastResult) {

--- a/web-ssr/benchmark.js
+++ b/web-ssr/benchmark.js
@@ -25,7 +25,8 @@ class Benchmark extends StartupBenchmark {
   }
 
   runIteration(iteration) {
-    let sourceCode = this.iterationSourceCodes[iteration];
+    // super.prepareForNextIteration() sets this up for us.
+    let sourceCode = this.currentIterationSourceCode;
     if (!sourceCode)
       throw new Error(`Could not find source for iteration ${iteration}`);
     // Module in sourceCode it assigned to the ReactRenderTest variable.
@@ -41,7 +42,7 @@ class Benchmark extends StartupBenchmark {
 
     const loadTime = runStart - initStart;
     const runTime = end - runStart;
-    // For local debugging: 
+    // For local debugging:
     // print(`Iteration ${iteration}:`);
     // print(`  Load time: ${loadTime.toFixed(2)}ms`);
     // print(`  Render time: ${runTime.toFixed(2)}ms`);


### PR DESCRIPTION
Right now StartupBenchmark builds all the sources it will need up front. This adds somewhat substantial memory overhead, in particular for jsdom-d3-startup where it seems to add about 50MB of overhead.

This patch changes it so the source is generated in the prepareForNextIteration hook on demand before the next iteration starts.

I also got rid of the unused zero sourceCodeReuseCount behavior where it didn't change the source code. It made the code more complex and seems like you wouldn't use StartupBenchmark in that case anyway.