### PR TITLE
async-fs / sync-fs should generate all possible bytes

### DIFF
--- a/generators/async-file-system.js
+++ b/generators/async-file-system.js
@@ -43,7 +43,7 @@ async function *randomFileContents() {
         let result = new ArrayBuffer(numBytes);
         let view = new Uint8Array(result);
         for (let i = 0; i < numBytes; ++i)
-            view[i] = (i + counter) % 255;
+            view[i] = (i + counter) % 256;
         yield new DataView(result);
     }
 }

--- a/generators/sync-file-system.js
+++ b/generators/sync-file-system.js
@@ -43,7 +43,7 @@ function *randomFileContents() {
         let result = new ArrayBuffer(numBytes);
         let view = new Uint8Array(result);
         for (let i = 0; i < numBytes; ++i)
-            view[i] = (i + counter) % 255;
+            view[i] = (i + counter) % 256;
         yield new DataView(result);
     }
 };


### PR DESCRIPTION
randomFileContents are using (x % 255), but it only includes [0, 255). So, 0xff is not populated. I think probably (x % 256) is the right one