### PR TITLE
Use violet as non-standard base c

### DIFF
--- a/resources/JetStream.css
+++ b/resources/JetStream.css
@@ -73,7 +73,7 @@ table {
 }
 
 body.nonDefaultParams {
-    filter: hue-rotate(152deg);
+    filter: hue-rotate(53deg);
 }
 
 .nonDefaultParams .summary {


### PR DESCRIPTION
The current hue-rotate setting also changes originally red error message to be green which is a bit confusing. Using violet makes this a bit less confusing.

Before:
<img width="708" height="514" alt="Screenshot 2025-12-10 at 12 14 26" src="https://github.com/user-attachments/assets/e2537b0f-430d-4057-8db5-6f6ebbad117f" />

After:
<img width="769" height="533" alt="Screenshot 2025-12-10 at 12 14 10" src="https://github.com/user-attachments/assets/7d2b12d9-b08d-4154-be20-1b73a26f91dd" />

