### PR TITLE
Errors with Non-Standard Query Params Should Be Red

### DIFF
--- a/resources/JetStream.css
+++ b/resources/JetStream.css
@@ -41,6 +41,7 @@
     --benchmark-done-result-color: #4A4A4A;
     --gap: 3rem;
     --width: 200px;
+    --nonDefaultRotate: 152deg;
 }
 
 html,
@@ -73,7 +74,12 @@ table {
 }
 
 body.nonDefaultParams {
-    filter: hue-rotate(152deg);
+    filter: hue-rotate(var(--nonDefaultRotate));
+}
+
+/* error gets rotated too, rotate it back so it's still red */
+.nonDefaultParams .error {
+    filter: hue-rotate(calc(360deg - var(--nonDefaultRotate)));
 }
 
 .nonDefaultParams .summary {


### PR DESCRIPTION
Right now we rotate all colors in the body so the current the red color ends up green. We should rotate the error class back so that it ends up red again. I did this via a variable so if we change the rotate in the future error will automatically fix itself.