### PR TITLE
Add verbose option to the node server.

### DIFF
--- a/tests/run-browser.mjs
+++ b/tests/run-browser.mjs
@@ -24,7 +24,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-import serve from "./server.mjs";
+import { serve, optionDefinitions as serverOptionDefinitions } from "./server.mjs";
 import { Builder, Capabilities, logging } from "selenium-webdriver";
 import { Options as ChromeOptions } from "selenium-webdriver/chrome.js";
 import { Options as FirefoxOptions } from "selenium-webdriver/firefox.js";
@@ -80,8 +80,8 @@ function sleep(ms) {
 }
 
 const optionDefinitions = [
+    ...serverOptionDefinitions,
     { name: "browser", type: String, description: "Set the browser to test, choices are [safari, firefox, chrome, edge]. By default the $BROWSER env variable is used." },
-    { name: "port", type: Number, defaultValue: 8010, description: "Set the test-server port, The default value is 8010." },
     { name: "help", alias: "h", description: "Print this help text." },
     { name: "suite", type: String, defaultOption: true, typeLabel: `{underline choices}: ${VALID_TAGS.join(", ")}`, description: "Run a specific suite by name." }
 ];
@@ -142,7 +142,7 @@ process.once("uncaughtException", (err) => {
 });
 
 const PORT = options.port;
-const server = await serve(PORT);
+const server = await serve(options);
 
 async function runTests() {
     let success = true;

--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -29,12 +29,12 @@ import LocalWebServer from "local-web-server";
 
 const ROOT_DIR = path.join(process.cwd(), "./");
 
-const optionDefinitions = [
+export const optionDefinitions = [
     { name: "port", type: Number, defaultValue: 8010, description: "Set the test-server port, The default value is 8010." },
     { name: "verbose", type: Boolean, defaultValue: false, description: "Log all requests set to the server." },
 ];
 
-export default async function serve({ port, verbose }) {
+export async function serve({ port, verbose }) {
     if (!port)
         throw new Error("Port is required");
 


### PR DESCRIPTION
This is somewhat handy when checking if network requests happen during the benchmark run itself. I clear the screen then click start and if any resources are fetched logging will be printed to the terminal session. It doesn't catch network requests but those are more obvious during development.

For posterity, after a bit of debugging I realized that you have to pass options as `npm run server -- --verbose` rather than `npm run server --verbose`