### PR TITLE
Replace prefetch logic

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -255,11 +255,11 @@ class BrowserFileLoader {
             this._blobDataCache[resource] = blobDataOrPromise;
         }
         const blobData = await blobDataOrPromise;
-        if (globalThis.allIsGood)
-            this._updateCounter();
         // Replace the potential promise in the cache.
         this._blobDataCache[resource] = blobData;
         blobData.refCount++;
+        if (globalThis.allIsGood)
+            this._updateCounter();
         return blobData;
     }
 


### PR DESCRIPTION
- Completely asyncify the preload logic
- Move all file loading and caching to BrowserFileLoader
- BrowserFileLoader._blobDataCache now holds temporary promises while the data is still loaded
- BrowserFileLoader._loadBlob now does a retry with timeout in-place without the need for a separate global retry