### PR TITLE
Fix dev server output

### DIFF
--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -45,9 +45,7 @@ export const optionDefinitions = [
     },
 ];
 
-export async function serve(options) {
-    let { port, quiet } = options;
-
+export async function serve({ port, quiet }) {
     if (!port) throw new Error("Port is required");
 
     const ws = await LocalWebServer.create({


### PR DESCRIPTION
- verbose output by default (it's a dev server after all)
- add --quiet option
- Use "undefined" for quite option, instead of "none"  to avoid superfluous "none" outputs