### PR TITLE
Final results should be alphabetically sorted

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -1223,7 +1223,8 @@ class Benchmark {
     updateUIBeforeRunInBrowser() {
         const resultsBenchmarkUI = document.getElementById(`benchmark-${this.name}`);
         resultsBenchmarkUI.classList.add("benchmark-running");
-        resultsBenchmarkUI.scrollIntoView({ block: "nearest" });
+        const containerUI = resultsBenchmarkUI.parentNode;
+        containerUI.insertBefore(resultsBenchmarkUI, containerUI.firstChild);
 
         for (const id of this.allScoreIdentifiers())
             document.getElementById(id).innerHTML = "...";


### PR DESCRIPTION
Right now the results end in a reverse alphabetically sorted order. This looks weird. Ideally we would just change the order that we run tests but I worry that will change the results in a non-trivial way (although I didn't try directly).

In future JetStream versions we should revert this and sort the tests in the other direction.