### PR TITLE
The Scatter Plot Should Increase with the Score

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -1254,7 +1254,7 @@ class Benchmark {
             const result = scores[i];
             const cx = padding + i * xRatio;
             const cy = height - padding - (result - minResult) * yRatio;
-            const title = `Iteration ${i + 1}: ${uiFriendlyScore(result)}`;
+            const title = `Iteration ${i + 1}: ${uiFriendlyScore(result)} (${uiFriendlyDuration(this.results[i])})`;
             circlesSVG += `<circle cx="${cx}" cy="${cy}" r="${radius}"><title>${title}</title></circle>`;
         }
         plotContainer.innerHTML = `<svg width="${width}px" height="${height}px">${circlesSVG}</svg>`;


### PR DESCRIPTION
Right now when the score goes up the scatter plots go down. This is a bit confusing since a higher score is better. I think it would be clearer if the plots reflected this.