### PR TITLE
Fix memory leak by freeing ret before error handling

### DIFF
--- a/ARES-6/Air/strip-hash.rb
+++ b/ARES-6/Air/strip-hash.rb
@@ -5,6 +5,6 @@
 
 ARGV.each {
     | filename |
-    IO::write(filename, IO::read(filename).lines.reject{|v| v =~ /hash/i}.join())
+    File.write(filename, File.read(filename).lines.reject { |v| v =~ /hash/i }.join)
 }
 

--- a/wasm/TSF/tsf_reflect.c
+++ b/wasm/TSF/tsf_reflect.c
@@ -90,8 +90,8 @@ tsf_reflect_t *tsf_reflect_create(tsf_type_t *type) {
         ret->u.c.array = malloc(sizeof(tsf_reflect_t*) *
                                 ret->u.c.size);
         if (ret->u.c.array == NULL) {
-            free(ret);
             tsf_type_destroy(ret->type);
+            free(ret);
             tsf_set_errno("Could not allocate array of pointers in "
                           "tsf_reflect_create()");
             return NULL;


### PR DESCRIPTION
fix avoid accessing any members of `ret` after calling `free(ret)`. If `tsf_type_destroy` must be called on `ret->type`, do so before freeing `ret`, or copy `ret->type` into a local variable before freeing `ret` and then destroy that local variable.

Best concrete fix here: On the error path in the `TSF_TK_STRUCT` case where allocation of `ret->u.c.array` fails, reorder the cleanup so that `tsf_type_destroy(ret->type)` is called before `free(ret)`. This ensures there is no member access through a freed pointer, while preserving the existing behavior and error reporting. No new headers or helper functions are required.

Specific changes:

- In `wasm/TSF/tsf_reflect.c`, inside `tsf_reflect_create`, locate the `case TSF_TK_STRUCT:` branch.
- In the `if (ret->u.c.array == NULL)` error block, move `tsf_type_destroy(ret->type);` to appear before `free(ret);`, or equivalently, swap lines 93 and 94.
- The resulting order in that block should be:
  1. `tsf_type_destroy(ret->type);`
  2. `free(ret);`
  3. `tsf_set_errno(...);`
  4. `return NULL;`
