### PR TITLE
dotnet: move the Wasm compilation into the first run (cherry-pick)

### DIFF
--- a/wasm/dotnet/benchmark.js
+++ b/wasm/dotnet/benchmark.js
@@ -1,6 +1,6 @@
 class Benchmark {
     async init() {
-        const config = {
+        this.config = {
             mainAssemblyName: "dotnet.dll",
             globalizationMode: "custom",
             assets: [
@@ -123,10 +123,7 @@ class Benchmark {
                 }
             ]
         };
-
         this.dotnet = (await JetStream.dynamicImport(JetStream.preload.dotnetUrl)).dotnet;
-        this.api = await this.dotnet.withModuleConfig({ locateFile: e => e }).withConfig(config).create();
-        this.exports = await this.api.getAssemblyExports("dotnet.dll");
 
         // This drives the workload size for BenchTasks half of the test.
         this.benchTasksBatchSize = dotnetFlavor === "aot" ? 50 : 10;
@@ -137,6 +134,11 @@ class Benchmark {
         this.sceneHeight = dotnetFlavor === "aot" ? 100 : 50;
     }
     async runIteration() {
+        if (!this.exports) {
+            const api = await this.dotnet.withModuleConfig({ locateFile: e => e }).withConfig(this.config).create();
+            this.exports = await api.getAssemblyExports("dotnet.dll");
+        }
+
         await this.exports.Interop.RunIteration(this.benchTasksBatchSize, this.sceneWidth, this.sceneHeight, this.hardwareConcurrency);
     }
 }


### PR DESCRIPTION
Cherry pick of https://github.com/WebKit/JetStream/pull/268 into `JetStream3.0` branch as per discussion in linked PR.