### PR TITLE
Add Wasm descriptions to in-depth.html, grey out non-default workloads (backmerge of #275)

### DIFF
--- a/in-depth.html
+++ b/in-depth.html
@@ -46,89 +46,90 @@
 
             <p>
                 JetStream 3 combines together a variety of JavaScript and WebAssembly benchmarks, covering a variety of
-                advanced workloads and programming techniques, and reports a single score that
-                balances them using a geometric mean.
+                advanced workloads and programming techniques, and reports a single score that balances them using the
+                geometric mean.
             </p>
 
             <p>
-                Each benchmark measures a distinct workload, and no single optimization
-                technique is sufficient to speed up all benchmarks. Some benchmarks demonstrate tradeoffs, and
-                aggressive or specialized optimizations for one benchmark might make another benchmark slower.
+                Each benchmark measures a distinct workload, and no single optimization technique is sufficient to speed
+                up all benchmarks.
+                Some benchmarks demonstrate tradeoffs, and aggressive or specialized optimizations for one benchmark
+                might make another benchmark slower.
                 JetStream 3 rewards browsers that start up quickly, execute code quickly, and continue running smoothly.
             </p>
 
             <p>
                 Each benchmark in JetStream 3 computes its own individual score.
-                Scores in JetStream are dimensionless floats, where a higher score is better.
+                Scores in JetStream are dimensionless floating point numbers, where a higher score is better.
                 JetStream weighs each benchmark equally, taking the <a
                     href="https://en.wikipedia.org/wiki/Geometric_mean">geometric mean</a> over each individual
                 benchmark's score to compute the overall JetStream 3 score.
                 The geometric mean ensures that a multiplicative improvement of any individual score has the same effect
                 on the aggregated score, regardless of the absolute value of the individual score.
                 For example, an improvement by 5% of the sub score of benchmark A has the same effect on the total score
-                as an improvement by 5% of the sub score of benchmark B.
+                as an improvement by 5% of the sub score of benchmark B, even if A ran for a shorter time than B.
             </p>
 
             <p>
                 It's not enough to just measure the total running time of a workload.
-                Browsers may perform differently for the same JavaScript workload depending on how many times it
-                has run. For example, garbage collection runs periodically, making some iterations take longer than
-                others. Code that runs repeatedly gets optimized by the browser, so the first iteration
-                of any workload is usually more expensive than the rest.
+                Browsers may perform differently for the same workload depending on how many times it has run.
+                For example, garbage collection runs periodically, making some iterations take longer than others.
+                Code that runs repeatedly gets optimized by the browser, so the first iteration of any workload is
+                usually more expensive than the rest.
             </p>
 
             <p>
-                For most of the JavaScript and WebAssembly benchmarks in JetStream 3, individual scores
-                equally weigh startup performance, worst case performance, and average case
-                performance. These three metrics are crucial to running performant JavaScript
-                in the browser. Fast startup times lead browsers to loading pages more quickly. Good
-                worst case performance ensures web applications can run without hiccups. Fast average
-                case performance makes it so that the most advanced web applications can run at all.
+                For most of the JavaScript and WebAssembly benchmarks in JetStream 3, individual scores equally weigh
+                startup performance, worst case performance, and average case performance.
+                These three metrics are crucial to running performant JavaScript and WebAssembly in the browser.
+                Fast startup times lead browsers to loading pages more quickly.
+                Good worst case performance ensures web applications can run without hiccups.
+                Fast average case performance makes it so that the most advanced web applications can run at all.
             </p>
 
             <p>
-                An important component of JetStream 1 were the asm.js subset of benchmarks. With the release
-                of WebAssembly, the importance of asm.js has lessened since many users of asm.js are
-                now using WebAssembly. JetStream 3 has converted many of the asm.js benchmarks from
-                JetStream 1 into WebAssembly.
-            </p>
-
-            <p>
-                All but one of JetStream 3's JavaScript benchmarks run for N iterations, where
-                N is usually 120. JetStream 3 reports the startup score as the time it takes to run the first iteration.
+                All but two of JetStream 3's benchmarks run for N iterations, where N is often 120.
+                JetStream 3 calculates the startup score from the time it takes to run the first iteration.
                 The worst case score is the average of the worst M iterations, excluding the first iteration.
-                M is always less than N, and is usually 4. The average case score is the average
-                of all but the first iteration. These three scores are weighed equally using the geometric
-                mean.
+                M is always less than N, and is usually 4.
+                The average case score is the average of all but the first iteration.
+                These three scores are weighed equally using the geometric mean.
             </p>
 
             <p>
-                JetStream 3 also includes a JavaScript benchmark named WSL. WSL is an implementation of a
-                GPU shading language written in JavaScript. WSL does not use the above mechanism for scoring
-                because it has a long running time. Instead, the WSL benchmark computes its score as the
-                geometric mean over two metrics: the time it takes to compile the WSL standard library, and the time
-                it takes to run through the WSL specification test suite.
+                JetStream 3 also includes a JavaScript benchmark named WSL.
+                WSL is an implementation of a GPU shading language written in JavaScript.
+                WSL does not use the above mechanism for scoring because it has a long running time.
+                Instead, the WSL benchmark computes its score as the geometric mean over two metrics: the time it takes
+                to compile the WSL standard library, and the time it takes to run through the WSL specification test
+                suite.
             </p>
 
             <p>
-                JetStream 3 includes parts of these benchmark suites that came before it: <a
-                    href="https://webkit.org/perf/sunspider/sunspider.html">SunSpider</a>,
-                <a href="https://developers.google.com/octane/">Octane 2</a>, <a
-                    href="https://browserbench.org/JetStream1.1/">JetStream 1</a>,
-                <a href="https://browserbench.org/ARES-6/">ARES-6</a>, <a
-                    href="https://v8.github.io/web-tooling-benchmark/">Web Tooling Benchmark</a>, and benchmarks
-                inspired by <a href="https://krakenbenchmark.mozilla.org">Kraken</a>.
+                JetStream 3 includes parts of these benchmark suites that came before it:
+                <a href="https://webkit.org/perf/sunspider/sunspider.html">SunSpider</a>,
+                <a href="https://developers.google.com/octane/">Octane 2</a>,
+                <a href="https://browserbench.org/JetStream2.1/">JetStream 2</a>,
+                <a href="https://browserbench.org/ARES-6/">ARES-6</a>,
+                <a href="https://v8.github.io/web-tooling-benchmark/">Web Tooling Benchmark</a>,
+                and benchmarks inspired by <a href="https://krakenbenchmark.mozilla.org">Kraken</a>.
                 JetStream 3 also includes a new set of benchmarks that measure the performance of WebAssembly, Web
-                Workers,
-                Promises, async iteration, unicode regular expressions, and JavaScript parsing.
+                Workers, Promises, async iteration, unicode regular expressions, and JavaScript parsing.
             </p>
 
             <p>
-                JetStream 3 includes several benchmarks from earlier JetStream versions, but updates the benchmark
-                driver to
-                improve score stability. This is achieved by pre-fetching network resources prior to running
-                the benchmarks. This can reduce perturbations on the measurement of JavaScript execution
-                time due to second order effects of pause times induced by network latency.
+                Earlier versions of JetStream also contained asm.js workloads.
+                With the release of WebAssembly, developers should switch to that technology instead.
+                JetStream 3 thus contains no asm.js workloads any longer and has converted some of the prior ones into
+                WebAssembly.
+            </p>
+
+            <p>
+                Besides the aforementioned averaging over multiple iterations, the JetStream 3 benchmark driver also
+                tries to improve score stability by other means.
+                For example, it pre-fetches network resources prior to running the benchmarks.
+                This can reduce perturbations on the measurement of JavaScript execution time due to second order
+                effects of pause times induced by network latency.
             </p>
 
             <p>
@@ -137,19 +138,22 @@
             </p>
 
             <h3>
-                JetStream 3 has 64 subtests:
+                JetStream 3 has 77 default workloads
             </h3>
+
+            <p>
+                The <span style="color: var(--text-color-very-subtle);">greyed-out workloads</span> are not run by default but can be manually enabled on the command-line or via
+                the <i>testList</i> URL parameter.
+            </p>
 
             <dl id="workload-details">
                 <dt id="8bitbench-wasm">8bitbench-wasm</dt>
                 <dd>
-                    A simple 8-bit emulator targeting wasm, written in rust. It aims to represent what an emulator or
-                    small game might act like in the real world.
-                    <br>
-                    Attribution: See <a href="8bitbench/ABOUT.md">8bitbench/ABOUT.md</a>
-                    <br>
-                    Source code: <a href="8bitbench/js3harness.js">8bitbench/js3harness.js</a>, based off <a
-                        href="https://github.com/justinmichaud/8bitbench">https://github.com/justinmichaud/8bitbench</a>
+                    A simple 8-bit emulator targeting WebAssembly written in Rust. It aims to represent what an emulator
+                    or small game might act like in the real world.
+                    Attribution: See <a href="8bitbench/README.md">8bitbench/README.md</a>.
+                    Source code: In the <a href="8bitbench/">8bitbench/</a> directory, based off <a
+                        href="https://github.com/justinmichaud/8bitbench">https://github.com/justinmichaud/8bitbench</a>.
                 </dd>
                 <dt id="acorn-wtb">acorn-wtb</dt>
                 <dd>
@@ -180,9 +184,10 @@
                 <dt id="argon2-wasm">argon2-wasm</dt>
                 <dd>
                     Tests <a href="https://github.com/P-H-C/phc-winner-argon2">Argon2</a>, a password-hashing function
-                    (the winner of Password Hashing Competition), in WebAssembly. This is test is based on <a
-                        href="https://github.com/antelle/argon2-browser">argon2-browser</a> library. Source code: <a
-                        href="wasm/">ARGON2</a>.
+                    (the winner of Password Hashing Competition), in WebAssembly. It makes use of the WebAssembly SIMD
+                    feature.
+                    This is test is based on <a href="https://github.com/antelle/argon2-browser">argon2-browser</a>
+                    library. Source code: In the <a href="wasm/argon2/">wasm/argon2/</a> directory.
                 </dd>
                 <dt id="async-fs">async-fs</dt>
                 <dd>
@@ -218,10 +223,10 @@
                     A similar version of this benchmark was previously published in the Web Tooling Benchmark.
                     Source code: <a href="web-tooling-benchmark/browser.js">babylon.js</a>
                 </dd>
-                <dt id="babylonjs-scene-es5">babylon-scene-es6</dt>
-                <dt id="babylonjs-scene-es6">babylon-scene-es6</dt>
-                <dt id="babylonjs-startup-es5">babylon-startup-es5</dt>
-                <dt id="babylonjs-startup-es6">babylon-startup-es6</dt>
+                <dt id="babylonjs-scene-es5" class="non-default">babylonjs-scene-es5</dt>
+                <dt id="babylonjs-scene-es6">babylonjs-scene-es6</dt>
+                <dt id="babylonjs-startup-es5" class="non-default">babylonjs-startup-es5</dt>
+                <dt id="babylonjs-startup-es6">babylonjs-startup-es6</dt>
                 <dd>TODO</dd>
                 <dt id="Basic">Basic</dt>
                 <dd>
@@ -233,14 +238,14 @@
                     This benchmark was previously published in ARES-6.
                     Source code: <a href="ARES-6/Basic">Basic</a>
                 </dd>
-                <dt id="bigint-bigdenary">bigint-bigdenary</dt>
+                <dt id="bigint-bigdenary" class="non-default">bigint-bigdenary</dt>
                 <dd>
                     <a href="https://github.com/uzyn/bigdenary">BigDenary</a>, an arbitrary-precision
                     decimal arithmetic, implemented in JavaScript by U-Zyn Chua.
                     Tests arithmetic operations on BigInt.
                     Source code: <a href="bigint/bigdenary-bundle.js">bigdenary-bundle.js</a>
                 </dd>
-                <dt id="bigint-noble-bls12-381">bigint-noble-bls12-381</dt>
+                <dt id="bigint-noble-bls12-381" class="non-default">bigint-noble-bls12-381</dt>
                 <dd>
                     <a href="https://hackmd.io/@benjaminion/bls12-381">BLS12-381</a>, pairing-friendly
                     Barreto-Lynn-Scott elliptic curve construction,
@@ -256,7 +261,7 @@
                     by Paul Miller. Tests typed arrays and arithmetic operations on BigInt.
                     Source code: <a href="bigint/noble-ed25519-bundle.js">noble-ed25519-bundle.js</a>
                 </dd>
-                <dt id="bigint-noble-secp256k1">bigint-noble-secp256k1</dt>
+                <dt id="bigint-noble-secp256k1" class="non-default">bigint-noble-secp256k1</dt>
                 <dd>
                     <a href="https://www.secg.org/sec2-v2.pdf">secp256k1</a>, an elliptic curve that could
                     be used for asymmetric encryption, ECDH key agreement protocol and signature schemes,
@@ -264,7 +269,7 @@
                     by Paul Miller. Tests typed arrays and arithmetic operations on BigInt.
                     Source code: <a href="bigint/noble-secp256k1-bundle.js">noble-secp256k1-bundle.js</a>
                 </dd>
-                <dt id="bigint-paillier">bigint-paillier</dt>
+                <dt id="bigint-paillier" class="non-default">bigint-paillier</dt>
                 <dd>
                     <a href="https://en.wikipedia.org/wiki/Paillier_cryptosystem">Paillier cryptosystem</a>,
                     a probabilistic asymmetric algorithm for public key cryptography,
@@ -308,10 +313,19 @@
                     A similar version of this benchmark was previously published in Octane version 2.
                     Source code: <a href="Octane/crypto.js">crypto.js</a>
                 </dd>
-                <dt id="Dart-flute-complex-wasm">Dart-flute-complex-wasm</dt>
-                <dd>TODO</dd>
+                <dt id="Dart-flute-complex-wasm" class="non-default">Dart-flute-complex-wasm</dt>
                 <dt id="Dart-flute-todomvc-wasm">Dart-flute-todomvc-wasm</dt>
-                <dd>TODO</dd>
+                <dd>
+                    Two Dart benchmark programs compiled to WasmGC that are using a simplified version of the Flutter UI
+                    framework to layout and animate UI elements.
+                    The <i>complex</i> variant contains a large number of widgets and is thus more of a stress test,
+                    disabled by default in JetStream 3.
+                    The <i>todomvc</i> variant is a more realistic TODO list application and enabled by default.
+                    See <a href="Dart/README.md">Dart/README.md</a> for more information.
+                    <br>
+                    Source code: in the <a href="Dart/">Dart/</a> directory, based off <a
+                        href="https://github.com/dart-lang/flute">https://github.com/dart-lang/flute</a>.
+                </dd>
                 <dt id="delta-blue">delta-blue</dt>
                 <dd>
                     The classic DeltaBlue benchmark derived from a Smalltalk implementation by Maloney and
@@ -321,18 +335,14 @@
                     Source code: <a href="Octane/deltablue.js">deltablue.js</a>
                 </dd>
                 <dt id="dotnet-aot-wasm">dotnet-aot-wasm</dt>
-                <dd>
-                    Tests <a href="https://github.com/dotnet/runtime">.NET on WebAssembly</a>. This benchmark tests
-                    operations
-                    on .NET implementation of String, JSON serialization, specifics of .NET exceptions and computation
-                    of a 3D scene using Mono AOT. Source code: <a href="wasm/dotnet">.NET</a>.
-                </dd>
                 <dt id="dotnet-interp-wasm">dotnet-interp-wasm</dt>
                 <dd>
-                    Tests <a href="https://github.com/dotnet/runtime">.NET on WebAssembly</a>. This benchmark tests
-                    operations
-                    on .NET implementation of String, JSON serialization, specifics of .NET exceptions and computation
-                    of a 3D scene using Mono Interpreter. Source code: <a href="wasm/dotnet">.NET</a>.
+                    These two workloads test <a href="https://github.com/dotnet/runtime">.NET on WebAssembly</a>.
+                    They contain a variety of operations on .NET strings, JSON serialization, specifics of .NET
+                    exceptions, and ray tracing of a 3D scene.
+                    The <i>aot</i> variant uses Mono AOT (ahead of time) compilation.
+                    The <i>interp</i> variant uses the Mono interpreter.
+                    Source code: In the <a href="wasm/dotnet/">wasm/dotnet/</a> directory.
                 </dd>
                 <dt id="doxbee-async">doxbee-async</dt>
                 <dd>
@@ -410,7 +420,7 @@
                     Source code: <a href="Octane/gbemu-part1.js">gbemu-part1.js</a>, <a
                         href="Octane/gbemu-part2.js">gbemu-part2.js</a>
                 </dd>
-                <dt id="gcc-loops-wasm">gcc-loops-wasm</dt>
+                <dt id="gcc-loops-wasm" class="non-default">gcc-loops-wasm</dt>
                 <dd>
                     Example loops used to tune the GCC and LLVM vectorizers, compiled to WebAssembly with
                     <a href="https://emscripten.org">Emscripten</a>. The original C++ version of this benchmark was
@@ -426,17 +436,21 @@
                     of this benchmark was originally published as part of the WebKit test suite.
                     Source code: <a href="simple/hash-map.js">hash-map.js</a>
                 </dd>
-                <dt id="HashSet-wasm">HashSet-wasm</dt>
+                <dt id="HashSet-wasm" class="non-default">HashSet-wasm</dt>
                 <dd>
                     A WebAssembly benchmark replaying a set of hash table operations performed in WebKit when loading
                     a web page. This benchmark was compiled from C++ to WebAssembly using <a
                         href="https://emscripten.org">Emscripten</a>.
                     Source code: <a href="wasm/HashSet.cpp">HashSet.cpp</a>, <a href="wasm/HashSet.js">HashSet.js</a>
                 </dd>
-                <dt id="intl">intl</dt>
+                <dt id="intl" class="non-default">intl</dt>
                 <dd>TODO</dd>
                 <dt id="j2cl-box2d-wasm">j2cl-box2d-wasm</dt>
-                <dd>TODO</dd>
+                <dd>
+                    A Java Box2D benchmark that is compiled to WasmGC with the <a
+                        href="https://github.com/google/j2cl">J2CL</a> toolchain.
+                    Source code: In the <a href="wasm/j2cl-box2d/">wasm/j2cl-box2d/</a> directory.
+                </dd>
                 <dt id="js-tokens">js-tokens</dt>
                 <dd>
                     This benchmarks runs <a href="https://github.com/lydell/js-tokens">js-tokens</a>, a lenient and
@@ -463,7 +477,15 @@
                     Source code: <a href="SeaMonster/json-stringify-inspector.js">json-stringify-inspector.js</a>
                 </dd>
                 <dt id="Kotlin-compose-wasm">Kotlin-compose-wasm</dt>
-                <dd></dd>
+                <dd>
+                    This benchmark is a Kotlin application using the <a href="https://jb.gg/cmp">Compose
+                        Multiplatform</a> UI framework.
+                    Compose allows to share UI code across multiple platforms and is compiled with <a
+                        href="https://kotl.in/wasm">Kotlin/Wasm</a> to WasmGC.
+                    Source code: In the <a href="Kotlin-compose/">Kotlin-compose/</a> directory, based off the benchark
+                    in <a
+                        href="https://github.com/JetBrains/compose-multiplatform/tree/master/benchmarks/multiplatform">https://github.com/JetBrains/compose-multiplatform/</a>.
+                </dd>
                 <dt id="lazy-collections">lazy-collections</dt>
                 <dd>
                     This benchmark iterates over common integer sequences (fibonacci, prime numbers, etc) as lazy
@@ -472,13 +494,13 @@
                     generators.
                     Source code: <a href="generators/lazy-collections.js">lazy-collections.js</a>
                 </dd>
-                <dt id="lebab-wtb"></dt>
+                <dt id="lebab-wtb" class="non-default">lebab-wtb</dt>
                 <dd>
-                <a href="https://github.com/lebab/lebab">Lebab</a> transpiles ES5 code into ES6/ES7.
-                This benchmark runs Lebab on test JavaScript programs.
-                This benchmark stresses string manipulation and regular expression performance.
-                A similar version of this benchmark was previously published in the Web Tooling Benchmark.
-                Source code: <a href="web-tooling-benchmark/browser.js">lebab.js</a>
+                    <a href="https://github.com/lebab/lebab">Lebab</a> transpiles ES5 code into ES6/ES7.
+                    This benchmark runs Lebab on test JavaScript programs.
+                    This benchmark stresses string manipulation and regular expression performance.
+                    A similar version of this benchmark was previously published in the Web Tooling Benchmark.
+                    Source code: <a href="web-tooling-benchmark/browser.js">lebab.js</a>
                 </dd>
                 <dt id="mandreel">mandreel</dt>
                 <dd>
@@ -538,9 +560,9 @@
                 </dd>
                 <dt id="postcss-wtb">postcss-wtb</dt>
                 <dd>TODO</dd>
-                <dt id="prettier-wtb"></dt>
+                <dt id="prettier-wtb">prettier-wtb</dt>
                 <dd>TODO</dd>
-                <dt id="prismjs-startup-es5">prismjs-startup-es5</dt>
+                <dt id="prismjs-startup-es5" class="non-default">prismjs-startup-es5</dt>
                 <dt id="prismjs-startup-es6">prismjs-startup-es6</dt>
                 <dd>TODO</dd>
                 <dt id="proxy-mobx">proxy-mobx</dt>
@@ -559,7 +581,7 @@
                     Tests get / set Proxy traps, as well as various Array methods.
                     Source code: <a href="proxy/vue-benchmark.js">vue-benchmark.js</a>
                 </dd>
-                <dt id="quicksort-wasm">quicksort-wasm</dt>
+                <dt id="quicksort-wasm" class="non-default">quicksort-wasm</dt>
                 <dd>
                     Quicksort benchmark, compiled to WebAssembly with <a href="https://emscripten.org">Emscripten</a>.
                     The original C version of this benchmark was previously published in the LLVM test suite.
@@ -609,10 +631,10 @@
                 </dd>
                 <dt id="richards-wasm">richards-wasm</dt>
                 <dd>
-                    Martin Richard's <a href="http://www.cl.cam.ac.uk/~mr10/Bench.html">system language
-                        benchmark</a> compiled to a hybrid of WebAssembly and JavaScript. It stresses how quickly
-                    JavaScript can call into WebAssembly code.
-                    Source code: <a href="wasm/richards.c">richards.c</a>, <a href="wasm/richards.js">richards.js</a>
+                    Martin Richard's <a href="http://www.cl.cam.ac.uk/~mr10/Bench.html">system language benchmark</a>
+                    compiled to a hybrid of WebAssembly and JavaScript.
+                    It stresses how quickly JavaScript can call into WebAssembly code.
+                    Source code: in the <a href="wasm/richards/">wasm/richards/</a> directory.
                 </dd>
                 <dt id="segmentation">segmentation</dt>
                 <dd>
@@ -634,7 +656,17 @@
                     Source code: <a href="Octane/splay.js">splay.js</a>
                 </dd>
                 <dt id="sqlite3-wasm">sqlite3-wasm</dt>
-                <dd>TODO</dd>
+                <dd>
+                    A WebAssembly build of <a href="https://sqlite.org/index.html">SQLite</a>'s <i>speedtest1.c</i>
+                    benchmark program.
+                    Quoting from <a href="https://sqlite.org/cpu.html">its description</a>:
+                    "This program strives to exercise the SQLite library in a way that is typical of real-world
+                    applications."
+                    Since SQLite is a very widely used database and provides an official and popular upstream
+                    WebAssembly port, this is a realistic, larger WebAssembly program.
+                    See <a href="sqlite3/README.md">README.md</a> for more information.
+                    Source code: in the <a href="sqlite3/">sqlite3/</a> directory.
+                </dd>
                 <dt id="stanford-crypto-aes">stanford-crypto-aes</dt>
                 <dd>
                     Measures the performance of the <a
@@ -770,7 +802,8 @@
                     order of existing files.
                     Source code: <a href="generators/sync-file-system.js">sync-file-system.js</a>
                 </dd>
-                <dt id="tfjs-wasm">tfjs-wasm</dt>
+                <dt id="tfjs-wasm" class="non-default">tfjs-wasm</dt>
+                <dt id="tfjs-wasm-simd" class="non-default">tfjs-wasm-simd</dt>
                 <dd>
                     Tests <a href="https://github.com/tensorflow/tfjs">Tensorflow.js</a> pre-trained machine learning
                     models supported by <a
@@ -780,23 +813,35 @@
                     <a href="https://www.npmjs.com/package/@tensorflow-models/knn-classifier">knn-classifier</a>, <a
                         href="https://www.npmjs.com/package/@tensorflow-models/coco-ssd">coco-ssd</a>, <a
                         href="https://www.npmjs.com/package/@tensorflow-models/universal-sentence-encoder">universal-sentence-encoder</a>.
-                    Source code: <a href="wasm/">TFJS</a>.
+                    The <i>SIMD</i> variant uses vector instructions from the Wasm SIMD feature.
+                    Source code: tfjs-* files in the <a href="wasm/">wasm/</a> directory.
                 </dd>
-                <dt id="tfjs-wasm-simd">tfjs-wasm-simd</dt>
-                <dd>TODO</dd>
                 <dt id="threejs">threejs</dt>
                 <dd></dd>
-                <dt id="transformersjs-bert-wasm">transformersjs-bert-wasm"</dt>
-                <dd>TODO</dd>
-                <dt id="transformersjs-whisper-wasm">transformersjs-whisper-wasm</dt>
-                <dd>TODO</dd>
+                <dt id="transformersjs-bert-wasm">transformersjs-bert-wasm</dt>
+                <dt id="transformersjs-whisper-wasm" class="non-default">transformersjs-whisper-wasm</dt>
+                <dd>
+                    Two machine learning tasks using the <a
+                        href="https://huggingface.co/docs/transformers.js/en/index">Transformers.js</a> library, which
+                    uses <a href="https://onnxruntime.ai/docs/tutorials/web/">ONNX Runtime Web</a> under the hood to
+                    perform inference with WebAssembly. They make use of WebAssembly SIMD instructions.
+                    The <i>bert</i> variant uses the <a
+                        href="https://huggingface.co/Xenova/distilbert-base-uncased-finetuned-sst-2-english">distilbert-base-uncased-finetuned-sst-2-english</a>
+                    model to perform sentiment analysis of text.
+                    The <i>whisper</i> variant uses <a
+                        href="https://huggingface.co/Xenova/whisper-tiny.en">whisper-tiny.en</a> to transcribe audio to
+                    text.
+                    Source code: in the <a href="transformersjs/">transformersjs/</a> directory.
+                </dd>
+
+                <dd>
                 <dt id="tsf-wasm">tsf-wasm</dt>
                 <dd>
-                    Runs Filip Pizlo's — of the WebKit team — implementation of a <a
-                        href="http://www.filpizlo.com/tsf/"> Typed Stream Format </a>
-                    in WebAssembly. The original code is compiled from C to WebAssembly using <a
+                    Runs Filip Pizlo's &mdash; of the WebKit team &mdash; implementation of a <a
+                        href="http://www.filpizlo.com/tsf/">Typed Stream Format</a> in WebAssembly.
+                    The original code is compiled from C to WebAssembly using <a
                         href="https://emscripten.org">Emscripten</a>.
-                    Source code: <a href="wasm/TSF">TSF</a>
+                    Source code: in the <a href="wasm/TSF/">wasm/TSF/</a> directory.
                 </dd>
                 <dt id="typescript-lib">typescript-lib</dt>
                 <dd>
@@ -806,7 +851,7 @@
                     A similar version of this benchmark was previously published in Octane version 2.
                     Source code: <a href="Octane/typescript.js">typescript.js</a>
                 </dd>
-                <dt id="typescript-octane">typescript-octane</dt>
+                <dt id="typescript-octane" class="non-default">typescript-octane</dt>
                 <dd>TODO</dd>
                 <dt id="UniPoker">UniPoker</dt>
                 <dd>
@@ -830,7 +875,12 @@
                     Source code: <a href="WSL">WSL</a>
                 </dd>
                 <dt id="zlib-wasm">zlib-wasm</dt>
-                <dd>zlib-wasm</dd>
+                <dd>
+                    This workload compresses and decompresses a WebAssembly binary file using the <a
+                        href="https://www.zlib.net/">zlib</a>
+                    library, compiled to WebAssembly via <a href="https://emscripten.org">Emscripten</a>.
+                    Source code: In the <a href="wasm/zlib/">wasm/zlib/</a> directory.
+                </dd>
             </dl>
 
             <p><a href="index.html" class="button">&larr; Return to Tests</a></p>

--- a/resources/JetStream.css
+++ b/resources/JetStream.css
@@ -28,7 +28,7 @@
     --color-secondary: #86d9ff;
     --text-color-inverse: white;
     --text-color-primary: black;
-    --text-color-secondary: #555555;
+    --text-color-secondary: #303030;
     --text-color-tertiary: #444444;
     --text-color-subtle: #6c6c71;
     --text-color-very-subtle: #8e8e93;
@@ -228,6 +228,7 @@ article {
     display: flex;
     flex-direction: column;
     gap: var(--gap);
+    padding-bottom: var(--gap);
 }
 h1 {
     color: var(--text-color-primary);
@@ -268,12 +269,22 @@ dt {
     margin-top: 10px;
     font-weight: bold;
     text-align: left;
+    color: var(--text-color-secondary);
+}
+
+dt.non-default {
+    color: var(--text-color-very-subtle);
+}
+
+dt.non-default:after {
+    content: " (not run by default)";
 }
 
 dd {
     text-align: left;
     padding: 10px 20px;
     margin: 0;
+    color: var(--text-color-secondary);
 }
 
 a:link,


### PR DESCRIPTION
As discussed in last week's meeting, this is a backmerge of #275 to the 3.0 branch (https://github.com/WebKit/JetStream/commit/6588e89fd812b13829025c00e60c27c9d3c389b5):

- Adds descriptions for all Wasm workloads.
- Extends the test to check that the `<dt>` tag text contents matches the `id="..."` id property.
- Adds a CSS style for non-default workloads (slightly grayed-out).
- Extends the text to check that all non-default workloads from the `JetStreamDriver.js` have this CSS class set.
- (very minor drive-by:) Add some padding at the bottom of in-depth.html

Fixes the wasm part of https://github.com/WebKit/JetStream/issues/199