### PR TITLE
Auto-add tags to in-depth.html (backmerge #288)

### DIFF
--- a/in-depth.html
+++ b/in-depth.html
@@ -27,14 +27,11 @@
 
 <head>
     <meta charset="utf-8" />
-
     <title>JetStream 3 In-Depth Analysis</title>
-
     <link rel="stylesheet" href="resources/JetStream.css">
-
 </head>
 
-<body class="overflow-scroll">
+<body class="in-depth overflow-scroll">
     <h1 class="logo">
         <div id="jetstreams">
             <a href="index.html" class="logo-image">JetStream 3</a>
@@ -143,7 +140,8 @@
 
             <p>
                 The <span style="color: var(--text-color-very-subtle);">greyed-out workloads</span> are not run by default but can be manually enabled on the command-line or via
-                the <i>testList</i> URL parameter.
+                the <code>?test=</code> URL parameter.
+                You can also click on the workload name to run that one individually, or on tags to run all workloads with a certain tag.
             </p>
 
             <dl id="workload-details">
@@ -223,9 +221,9 @@
                     A similar version of this benchmark was previously published in the Web Tooling Benchmark.
                     Source code: <a href="web-tooling-benchmark/browser.js">babylon.js</a>
                 </dd>
-                <dt id="babylonjs-scene-es5" class="non-default">babylonjs-scene-es5</dt>
+                <dt id="babylonjs-scene-es5">babylonjs-scene-es5</dt>
                 <dt id="babylonjs-scene-es6">babylonjs-scene-es6</dt>
-                <dt id="babylonjs-startup-es5" class="non-default">babylonjs-startup-es5</dt>
+                <dt id="babylonjs-startup-es5">babylonjs-startup-es5</dt>
                 <dt id="babylonjs-startup-es6">babylonjs-startup-es6</dt>
                 <dd>TODO</dd>
                 <dt id="Basic">Basic</dt>
@@ -238,14 +236,14 @@
                     This benchmark was previously published in ARES-6.
                     Source code: <a href="ARES-6/Basic">Basic</a>
                 </dd>
-                <dt id="bigint-bigdenary" class="non-default">bigint-bigdenary</dt>
+                <dt id="bigint-bigdenary">bigint-bigdenary</dt>
                 <dd>
                     <a href="https://github.com/uzyn/bigdenary">BigDenary</a>, an arbitrary-precision
                     decimal arithmetic, implemented in JavaScript by U-Zyn Chua.
                     Tests arithmetic operations on BigInt.
                     Source code: <a href="bigint/bigdenary-bundle.js">bigdenary-bundle.js</a>
                 </dd>
-                <dt id="bigint-noble-bls12-381" class="non-default">bigint-noble-bls12-381</dt>
+                <dt id="bigint-noble-bls12-381">bigint-noble-bls12-381</dt>
                 <dd>
                     <a href="https://hackmd.io/@benjaminion/bls12-381">BLS12-381</a>, pairing-friendly
                     Barreto-Lynn-Scott elliptic curve construction,
@@ -261,7 +259,7 @@
                     by Paul Miller. Tests typed arrays and arithmetic operations on BigInt.
                     Source code: <a href="bigint/noble-ed25519-bundle.js">noble-ed25519-bundle.js</a>
                 </dd>
-                <dt id="bigint-noble-secp256k1" class="non-default">bigint-noble-secp256k1</dt>
+                <dt id="bigint-noble-secp256k1">bigint-noble-secp256k1</dt>
                 <dd>
                     <a href="https://www.secg.org/sec2-v2.pdf">secp256k1</a>, an elliptic curve that could
                     be used for asymmetric encryption, ECDH key agreement protocol and signature schemes,
@@ -269,7 +267,7 @@
                     by Paul Miller. Tests typed arrays and arithmetic operations on BigInt.
                     Source code: <a href="bigint/noble-secp256k1-bundle.js">noble-secp256k1-bundle.js</a>
                 </dd>
-                <dt id="bigint-paillier" class="non-default">bigint-paillier</dt>
+                <dt id="bigint-paillier">bigint-paillier</dt>
                 <dd>
                     <a href="https://en.wikipedia.org/wiki/Paillier_cryptosystem">Paillier cryptosystem</a>,
                     a probabilistic asymmetric algorithm for public key cryptography,
@@ -313,7 +311,7 @@
                     A similar version of this benchmark was previously published in Octane version 2.
                     Source code: <a href="Octane/crypto.js">crypto.js</a>
                 </dd>
-                <dt id="Dart-flute-complex-wasm" class="non-default">Dart-flute-complex-wasm</dt>
+                <dt id="Dart-flute-complex-wasm">Dart-flute-complex-wasm</dt>
                 <dt id="Dart-flute-todomvc-wasm">Dart-flute-todomvc-wasm</dt>
                 <dd>
                     Two Dart benchmark programs compiled to WasmGC that are using a simplified version of the Flutter UI
@@ -420,7 +418,7 @@
                     Source code: <a href="Octane/gbemu-part1.js">gbemu-part1.js</a>, <a
                         href="Octane/gbemu-part2.js">gbemu-part2.js</a>
                 </dd>
-                <dt id="gcc-loops-wasm" class="non-default">gcc-loops-wasm</dt>
+                <dt id="gcc-loops-wasm">gcc-loops-wasm</dt>
                 <dd>
                     Example loops used to tune the GCC and LLVM vectorizers, compiled to WebAssembly with
                     <a href="https://emscripten.org">Emscripten</a>. The original C++ version of this benchmark was
@@ -436,15 +434,22 @@
                     of this benchmark was originally published as part of the WebKit test suite.
                     Source code: <a href="simple/hash-map.js">hash-map.js</a>
                 </dd>
-                <dt id="HashSet-wasm" class="non-default">HashSet-wasm</dt>
+                <dt id="HashSet-wasm">HashSet-wasm</dt>
                 <dd>
                     A WebAssembly benchmark replaying a set of hash table operations performed in WebKit when loading
                     a web page. This benchmark was compiled from C++ to WebAssembly using <a
                         href="https://emscripten.org">Emscripten</a>.
                     Source code: <a href="wasm/HashSet.cpp">HashSet.cpp</a>, <a href="wasm/HashSet.js">HashSet.js</a>
                 </dd>
-                <dt id="intl" class="non-default">intl</dt>
-                <dd>TODO</dd>
+                <dt id="intl">intl</dt>
+                <dd>
+                    This benchmark tests the performance of the <a
+                        href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl">Intl
+                        API</a>.
+                    Since the Intl spec is not precisely defining all output formats, this workload cannot be used to
+                    compare different platforms.
+                    Source code: in the <a href="intl/">intl/</a> directory.
+                </dd>
                 <dt id="j2cl-box2d-wasm">j2cl-box2d-wasm</dt>
                 <dd>
                     A Java Box2D benchmark that is compiled to WasmGC with the <a
@@ -494,7 +499,7 @@
                     generators.
                     Source code: <a href="generators/lazy-collections.js">lazy-collections.js</a>
                 </dd>
-                <dt id="lebab-wtb" class="non-default">lebab-wtb</dt>
+                <dt id="lebab-wtb">lebab-wtb</dt>
                 <dd>
                     <a href="https://github.com/lebab/lebab">Lebab</a> transpiles ES5 code into ES6/ES7.
                     This benchmark runs Lebab on test JavaScript programs.
@@ -581,7 +586,7 @@
                     Tests get / set Proxy traps, as well as various Array methods.
                     Source code: <a href="proxy/vue-benchmark.js">vue-benchmark.js</a>
                 </dd>
-                <dt id="quicksort-wasm" class="non-default">quicksort-wasm</dt>
+                <dt id="quicksort-wasm">quicksort-wasm</dt>
                 <dd>
                     Quicksort benchmark, compiled to WebAssembly with <a href="https://emscripten.org">Emscripten</a>.
                     The original C version of this benchmark was previously published in the LLVM test suite.
@@ -802,8 +807,8 @@
                     order of existing files.
                     Source code: <a href="generators/sync-file-system.js">sync-file-system.js</a>
                 </dd>
-                <dt id="tfjs-wasm" class="non-default">tfjs-wasm</dt>
-                <dt id="tfjs-wasm-simd" class="non-default">tfjs-wasm-simd</dt>
+                <dt id="tfjs-wasm">tfjs-wasm</dt>
+                <dt id="tfjs-wasm-simd">tfjs-wasm-simd</dt>
                 <dd>
                     Tests <a href="https://github.com/tensorflow/tfjs">Tensorflow.js</a> pre-trained machine learning
                     models supported by <a
@@ -819,7 +824,7 @@
                 <dt id="threejs">threejs</dt>
                 <dd></dd>
                 <dt id="transformersjs-bert-wasm">transformersjs-bert-wasm</dt>
-                <dt id="transformersjs-whisper-wasm" class="non-default">transformersjs-whisper-wasm</dt>
+                <dt id="transformersjs-whisper-wasm">transformersjs-whisper-wasm</dt>
                 <dd>
                     Two machine learning tasks using the <a
                         href="https://huggingface.co/docs/transformers.js/en/index">Transformers.js</a> library, which
@@ -885,8 +890,45 @@
 
             <p><a href="index.html" class="button">&larr; Return to Tests</a></p>
         </article>
-
     </main>
-</body>
 
+    <script>
+        const isInBrowser = true;
+    </script>
+    <script src="utils/params.js"></script>
+    <script src="JetStreamDriver.js"></script>
+    <script>
+        (function () {
+            for (const benchmark of BENCHMARKS) {
+                let dt = document.getElementById(benchmark.name);
+                if (!dt) {
+                    continue;
+                }
+
+                if (benchmark.tags.has("disabled")) {
+                    dt.classList.add("non-default");
+                }
+
+                const nameLink = document.createElement("a");
+                nameLink.href = `index.html?test=${benchmark.name}`;
+                nameLink.className = "workload-link";
+                nameLink.textContent = dt.textContent;
+                dt.textContent = "";
+                dt.appendChild(nameLink);
+                                          
+                const tags = Array.from(benchmark.tags).sort();
+                for (const tag of tags) {
+                    if (tag === "all" || tag === "default") {
+                        continue;
+                    }
+                    const link = document.createElement("a");
+                    link.href = `index.html?tags=${tag}`;
+                    link.textContent = tag;
+                    link.className = "tag-link";
+                    dt.appendChild(link);
+                }
+            }
+        })();
+    </script>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
 </h1>
 
 <main>
-    <p class="summary">JetStream 3 is a JavaScript and WebAssembly benchmark suite focused on the most advanced web applications. It rewards browsers that start up quickly, execute code quickly, and run smoothly. For more information, read the <a href="/in-depth.html">in-depth analysis</a>. Bigger scores are better.</p>
+    <p class="summary">JetStream 3 is a JavaScript and WebAssembly benchmark suite focused on the most advanced web applications. It rewards browsers that start up quickly, execute code quickly, and run smoothly. For more information, read the <a href="in-depth.html">in-depth analysis</a>. Bigger scores are better.</p>
     <div id="non-default-params">
         <h2>Non-standard Parameters</h2>
         <p>

--- a/resources/JetStream.css
+++ b/resources/JetStream.css
@@ -265,24 +265,67 @@ h6 {
     color: var(--text-color-tertiary);
 }
 
+.in-depth h2,
+.in-depth h3,
+.in-depth dl {
+    margin: 0;
+}
+
+dl > dt:first-child {
+    margin-top: 0;
+}
+
 dt {
-    margin-top: 10px;
+    margin-top: 0.5rem;
     font-weight: bold;
     text-align: left;
     color: var(--text-color-secondary);
+    line-height: 2rem;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+dt > a.workload-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+dt > a.workload-link:hover {
+    color: var(--color-primary);
+}
+
+.tag-link {
+    display: inline-block;
+    background-color: var(--color-secondary);
+    color: var(--text-color-secondary) !important;
+    padding: 0px 4px;
+    margin-left: 6px;
+    border-radius: 3px;
+    font-size: 1.2rem;
+    line-height: 1.8rem;
+    font-weight: normal;
+    text-decoration: none;
+}
+.tag-link::before {
+    content: "#";
+}
+
+.tag-link:hover {
+    background-color: var(--color-primary);
 }
 
 dt.non-default {
     color: var(--text-color-very-subtle);
 }
 
-dt.non-default:after {
+dt.non-default > *:first-child:after {
     content: " (not run by default)";
 }
 
 dd {
     text-align: left;
-    padding: 10px 20px;
+    padding: 0.5rem 0rem 1.5rem 2rem;
     margin: 0;
     color: var(--text-color-secondary);
 }

--- a/tests/run-browser.mjs
+++ b/tests/run-browser.mjs
@@ -291,14 +291,6 @@ async function inDepthPageTest(driver) {
         return a.toLowerCase().localeCompare(b.toLowerCase());
     });
 
-    const nonDefaultIds = benchmarkNames.filter(name => !benchmarkData.get(name).includes("default"));
-    for (const id of nonDefaultIds) {
-        const description = descriptions.get(id);
-        if (description && description.cssClass !== "non-default") {
-            sectionErrors.push(`Expected non-default benchmark '${id}' to have CSS class 'non-default' but got '${description.cssClass}'`);
-        }
-    }
-
     const missingIds = benchmarkNames.filter(name => !descriptions.has(name));
     if (missingIds.length > 0) {
         sectionErrors.push(`Missing in-depth.html info section: ${JSON.stringify(missingIds, undefined, 2)}`);


### PR DESCRIPTION
Use the benchmark definitions from JetStreamDriver.js to add tags to each workload title.

- Add tags
- Add links to run workload matching a tag
- Add links to run a single workload
- Improve in-depth.html css a bit to use less spacing around headers and the first definition
- Use relative link from index.html => in-depth.html 

Backmerge of #288 