### PR TITLE
Fix update-ui performance.measure nesting

### DIFF
--- a/JetStreamDriver.js
+++ b/JetStreamDriver.js
@@ -347,7 +347,8 @@ class Driver {
         performance.mark("update-ui-start");
         const start = performance.now();
         for (const benchmark of this.benchmarks) {
-            await benchmark.updateUIBeforeRun();
+            performance.mark("update-ui-start");
+            benchmark.updateUIBeforeRun();
             await updateUI();
             performance.measure("runner update-ui", "update-ui-start");
 
@@ -358,14 +359,14 @@ class Driver {
                 throw e;
             }
 
-            performance.mark("update-ui");
+            performance.mark("update-ui-start");
             benchmark.updateUIAfterRun();
+            performance.measure("runner update-ui", "update-ui-start");
 
             if (isInBrowser) {
                 browserFileLoader.free(benchmark.files);
             }
         }
-        performance.measure("runner update-ui", "update-ui-start");
 
         const totalTime = performance.now() - start;
         if (measureTotalTimeAsSubtest) {


### PR DESCRIPTION
The mark and measure calls were out of sync and caused unclosed scopes.